### PR TITLE
Fix: Missing main dispatcher override, race conditions & mock leakage

### DIFF
--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/SettingsViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/SettingsViewModelTest.kt
@@ -1,6 +1,7 @@
 package at.aau.serg.websocketbrokerdemo.ui
 
 import android.app.Application
+import at.aau.serg.websocketbrokerdemo.audio.MusicManager
 import at.aau.serg.websocketbrokerdemo.data.AppSettings
 import at.aau.serg.websocketbrokerdemo.data.SettingsRepository
 import at.aau.serg.websocketbrokerdemo.ui.settings.SettingsViewModel
@@ -8,9 +9,17 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -23,8 +32,13 @@ class SettingsViewModelTest {
 
     private lateinit var settingsFlow: MutableStateFlow<AppSettings>
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     @BeforeEach
     fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockkObject(MusicManager)
+
         // Mock Repository + Application
         repo = mockk(relaxed = true)
         app = mockk(relaxed = true)
@@ -37,11 +51,18 @@ class SettingsViewModelTest {
         viewModel = SettingsViewModel(app, repo)
     }
 
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
     @Test
     fun `setLanguage calls repository`() = runTest {
         coEvery { repo.setLanguage("de") } returns Unit
 
         viewModel.setLanguage("de")
+        advanceUntilIdle()
 
         coVerify { repo.setLanguage("de") }
     }
@@ -51,15 +72,17 @@ class SettingsViewModelTest {
         coEvery { repo.setMusicEnabled(true) } returns Unit
 
         viewModel.setMusicEnabled(true)
+        advanceUntilIdle()
 
         coVerify { repo.setMusicEnabled(true) }
     }
 
-    //@Test
+    @Test
     fun `setMusicVolume calls repository`() = runTest {
         coEvery { repo.setMusicVolume(0.7f) } returns Unit
 
         viewModel.setMusicVolume(0.7f)
+        advanceUntilIdle()
 
         coVerify { repo.setMusicVolume(0.7f) }
     }
@@ -69,6 +92,7 @@ class SettingsViewModelTest {
         coEvery { repo.setSfxEnabled(false) } returns Unit
 
         viewModel.setSfxEnabled(false)
+        advanceUntilIdle()
 
         coVerify { repo.setSfxEnabled(false) }
     }


### PR DESCRIPTION
Tests in SettingsViewModelTest seem to display unpredictable behaviour when running  ./gradlew clean build ([see Issue 76](https://github.com/HexaBrawl/app/issues/76)). 

Addressed the following issues:
- Missing Main Dispatcher override: SettingsViewModel uses viewModelScope.launch, which defaults to Dispatchers.Main. In unit tests, Dispatchers.Main must be substituted with a test dispatcher.
- Race conditions in verification: The tests are calling viewModel methods that launch coroutines and then immediately verifying the repository calls. Without waiting for the coroutines to complete (e.g., using advanceUntilIdle()), the verification could fail if the coroutine hadn't finished yet.
- Mock leakage: MusicManager is an object (singleton). If it's touched by one test and not reset, it can affect others. Also, mockk mocks should be cleared after each test.

Running ./gradlew clean build locally three times now leads to consistent successfull behaviour.