### PR TITLE
Reverted Gradle Version to 8.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.1"
+agp = "8.13.0"
 kotlin = "2.3.10"
 coreKtx = "1.18.0"
 junitJupiterApi = "5.10.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Wed Mar 05 12:08:28 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Changed the version of Gradle from 9.3.1 to 8.13.0 in libs.versions.toml and grdle-wrapper.properties.