### PR TITLE
Refactoring network layer - Phase 1

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -50,7 +50,7 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             try {
                 stomp.connect()
-                endpoint.subscribeToGameState { state ->
+                endpoint.subscribeToGameState(session.roomId.value) { state ->
                     session.gameState.value = state
                     session.gameStateReceivedCount.intValue += 1
                 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
@@ -20,6 +20,7 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.GameState
  */
 class GameSession(
     val endpoint: UnitMoveEndpoint,
+    val roomId: MutableState<String> = mutableStateOf("game1"),
     val gameState: MutableState<GameState?> = mutableStateOf(null),
     val lastError: MutableState<ErrorMessage?> = mutableStateOf(null),
     val localPlayerName: MutableState<String?> = mutableStateOf(null),

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
@@ -35,9 +35,9 @@ class UnitMoveEndpoint(
     private val gson = Gson()
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    fun subscribeToGameState(onGameState: (GameState) -> Unit): Job =
-        stomp.subscribe("/topic/game") { msg ->
-            Log.d(TAG, "<- /topic/game: $msg")
+    fun subscribeToGameState(roomId: String, onGameState: (GameState) -> Unit): Job =
+        stomp.subscribe("/topic/game/$roomId") { msg ->
+            Log.d(TAG, "<- /topic/game/$roomId: $msg")
             try {
                 onGameState(gson.fromJson(msg, GameState::class.java))
             } catch (e: Exception) {
@@ -55,16 +55,16 @@ class UnitMoveEndpoint(
             }
         }
 
-    fun sendMove(move: Move) {
+    fun sendMove(roomId: String, move: Move) {
         try {
             val json = gson.toJson(move)
-            Log.d(TAG, "-> /app/move: $json")
-            stomp.sendJson("/app/move", json)
+            Log.d(TAG, "-> /app/move/$roomId: $json")
+            stomp.sendJson("/app/move/$roomId", json)
 
             if (AZURE_MOVE_BROADCAST_WORKAROUND) {
                 scope.launch {
                     delay(POST_MOVE_REFRESH_DELAY_MS)
-                    requestInitialState()
+                    requestInitialState(roomId)
                 }
             }
         } catch (e: Exception) {
@@ -72,14 +72,14 @@ class UnitMoveEndpoint(
         }
     }
 
-    fun joinGame(playerName: String) {
-        Log.d(TAG, "-> /app/join: $playerName")
-        stomp.sendText("/app/join", playerName)
+    fun joinGame(roomId: String, playerName: String) {
+        Log.d(TAG, "-> /app/join/$roomId: $playerName")
+        stomp.sendText("/app/join/$roomId", playerName)
     }
 
-    fun requestInitialState() {
-        Log.d(TAG, "-> /app/init")
-        stomp.sendText("/app/init", "")
+    fun requestInitialState(roomId: String) {
+        Log.d(TAG, "-> /app/init/$roomId")
+        stomp.sendText("/app/init/$roomId", "")
     }
 
     companion object {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
@@ -36,8 +36,8 @@ class UnitMoveEndpoint(
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     fun subscribeToGameState(roomId: String, onGameState: (GameState) -> Unit): Job =
-        stomp.subscribe("/topic/game/$roomId") { msg ->
-            Log.d(TAG, "<- /topic/game/$roomId: $msg")
+        stomp.subscribe("/topic/rooms/$roomId/game") { msg ->
+            Log.d(TAG, "<- /topic/rooms/$roomId/game: $msg")
             try {
                 onGameState(gson.fromJson(msg, GameState::class.java))
             } catch (e: Exception) {
@@ -58,8 +58,8 @@ class UnitMoveEndpoint(
     fun sendMove(roomId: String, move: Move) {
         try {
             val json = gson.toJson(move)
-            Log.d(TAG, "-> /app/move/$roomId: $json")
-            stomp.sendJson("/app/move/$roomId", json)
+            Log.d(TAG, "-> /app/rooms/$roomId/move: $json")
+            stomp.sendJson("/app/rooms/$roomId/move", json)
 
             if (AZURE_MOVE_BROADCAST_WORKAROUND) {
                 scope.launch {
@@ -73,13 +73,13 @@ class UnitMoveEndpoint(
     }
 
     fun joinGame(roomId: String, playerName: String) {
-        Log.d(TAG, "-> /app/join/$roomId: $playerName")
-        stomp.sendText("/app/join/$roomId", playerName)
+        Log.d(TAG, "-> /app/rooms/$roomId/join: $playerName")
+        stomp.sendText("/app/rooms/$roomId/join", playerName)
     }
 
     fun requestInitialState(roomId: String) {
-        Log.d(TAG, "-> /app/init/$roomId")
-        stomp.sendText("/app/init/$roomId", "")
+        Log.d(TAG, "-> /app/rooms/$roomId/init/")
+        stomp.sendText("/app/rooms/$roomId/init/", "")
     }
 
     companion object {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
@@ -36,8 +36,8 @@ class UnitMoveEndpoint(
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     fun subscribeToGameState(roomId: String, onGameState: (GameState) -> Unit): Job =
-        stomp.subscribe("/topic/rooms/$roomId/game") { msg ->
-            Log.d(TAG, "<- /topic/rooms/$roomId/game: $msg")
+        stomp.subscribe("/topic/rooms/$roomId/state") { msg ->
+            Log.d(TAG, "<- /topic/rooms/$roomId/state: $msg")
             try {
                 onGameState(gson.fromJson(msg, GameState::class.java))
             } catch (e: Exception) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -65,7 +65,7 @@ fun GameScreen(
     var lastMove by remember { mutableStateOf<String>("-") }
 
     LaunchedEffect(Unit) {
-        if (gameState == null) session.endpoint.requestInitialState()
+        if (gameState == null) session.endpoint.requestInitialState(session.roomId.value)
     }
 
     LaunchedEffect(gameState?.currentTurn, gameState?.status, botName) {
@@ -76,7 +76,7 @@ fun GameScreen(
 
         delay(800)
         val move = pickBotMove(state, bot)
-        if (move != null) session.endpoint.sendMove(move)
+        if (move != null) session.endpoint.sendMove(session.roomId.value, move)
     }
 
     val units: List<GameUnit> = gameState?.units.orEmpty()
@@ -136,7 +136,7 @@ fun GameScreen(
                 )
                 lastMove = "${current.type} (${current.x},${current.y}) -> ($col,$row)"
                 session.lastError.value = null
-                session.endpoint.sendMove(move)
+                session.endpoint.sendMove(session.roomId.value, move)
                 selected = null
             }
         }
@@ -250,7 +250,7 @@ fun GameScreen(
                 modifier = Modifier.padding(top = 4.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Button(onClick = { session.endpoint.requestInitialState() }) {
+                Button(onClick = { session.endpoint.requestInitialState(session.roomId.value) }) {
                     Text("Refresh /app/init")
                 }
                 Button(onClick = { session.lastError.value = null }) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
@@ -108,7 +108,7 @@ fun SyncLobbyWithServer(
 
     LaunchedEffect(localName) {
         session.localPlayerName.value = localName
-        session.endpoint.joinGame(localName)
+        session.endpoint.joinGame(session.roomId.value, localName)
     }
 
     // Dev shortcut: if after a few seconds the backend still only has us,
@@ -122,7 +122,7 @@ fun SyncLobbyWithServer(
             if (!alreadyHasPartner && session.botPlayerName.value == null) {
                 val botName = "Bot-" + GENERAL_NAMES.random().substringAfter(' ')
                 session.botPlayerName.value = botName
-                session.endpoint.joinGame(botName)
+                session.endpoint.joinGame(session.roomId.value, botName)
             }
         }
     }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
@@ -32,12 +32,12 @@ class UnitMoveEndpointTest {
 
         val slot = slot<String>()
 
-        every { stomp.sendJson("/app/move", capture(slot)) } just Runs
+        every { stomp.sendJson("/app/move/game1", capture(slot)) } just Runs
 
-        endpoint.sendMove(move)
+        endpoint.sendMove("game1", move)
 
         verify {
-            stomp.sendJson(eq("/app/move"), any())
+            stomp.sendJson(eq("/app/move/game1"), any())
         }
 
         assert(slot.isCaptured)
@@ -47,20 +47,20 @@ class UnitMoveEndpointTest {
     @Test
     fun `joinGame sends player name as text`() {
 
-        endpoint.joinGame("Max")
+        endpoint.joinGame("game1", "Max")
 
         verify {
-            stomp.sendText("/app/join", "Max")
+            stomp.sendText("/app/join/game1", "Max")
         }
     }
 
     @Test
     fun `requestInitialState sends empty init message`() {
 
-        endpoint.requestInitialState()
+        endpoint.requestInitialState("game1")
 
         verify {
-            stomp.sendText("/app/init", "")
+            stomp.sendText("/app/init/game1", "")
         }
     }
 
@@ -70,12 +70,12 @@ class UnitMoveEndpointTest {
         val slot = slot<(String) -> Unit>()
 
         every {
-            stomp.subscribe("/topic/game", capture(slot))
+            stomp.subscribe("/topic/game/game1", capture(slot))
         } returns mockk(relaxed = true)
 
         var received: GameState? = null
 
-        endpoint.subscribeToGameState {
+        endpoint.subscribeToGameState("game1") {
             received = it
         }
 

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
@@ -70,7 +70,7 @@ class UnitMoveEndpointTest {
         val slot = slot<(String) -> Unit>()
 
         every {
-            stomp.subscribe("/topic/rooms/game1/game", capture(slot))
+            stomp.subscribe("/topic/rooms/game1/state", capture(slot))
         } returns mockk(relaxed = true)
 
         var received: GameState? = null

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
@@ -32,12 +32,12 @@ class UnitMoveEndpointTest {
 
         val slot = slot<String>()
 
-        every { stomp.sendJson("/app/move/game1", capture(slot)) } just Runs
+        every { stomp.sendJson("/app/rooms/game1/move", capture(slot)) } just Runs
 
         endpoint.sendMove("game1", move)
 
         verify {
-            stomp.sendJson(eq("/app/move/game1"), any())
+            stomp.sendJson(eq("/app/rooms/game1/move"), any())
         }
 
         assert(slot.isCaptured)
@@ -50,7 +50,7 @@ class UnitMoveEndpointTest {
         endpoint.joinGame("game1", "Max")
 
         verify {
-            stomp.sendText("/app/join/game1", "Max")
+            stomp.sendText("/app/rooms/game1/join", "Max")
         }
     }
 
@@ -60,7 +60,7 @@ class UnitMoveEndpointTest {
         endpoint.requestInitialState("game1")
 
         verify {
-            stomp.sendText("/app/init/game1", "")
+            stomp.sendText("/app/rooms/game1/init/", "")
         }
     }
 
@@ -70,7 +70,7 @@ class UnitMoveEndpointTest {
         val slot = slot<(String) -> Unit>()
 
         every {
-            stomp.subscribe("/topic/game/game1", capture(slot))
+            stomp.subscribe("/topic/rooms/game1/game", capture(slot))
         } returns mockk(relaxed = true)
 
         var received: GameState? = null


### PR DESCRIPTION
Began working on [Feature "Refactor Network Layer"](https://github.com/HexaBrawl/app/issues/65) and implemented:

- [UnitMoveEndpoint Methoden mit roomId als erstem Parameter](https://github.com/HexaBrawl/app/issues/67)
  - Changed the following functions to:
    -  subscribeToGameState(roomId, onGameState)
    -  sendMove(roomId, move)
    -  joinGame(roomId, PlayerName)
    - requestInitialState(roomId)
  - Changed useage of these functions to implement roomId

- [Added roomId into GameSession data class to bundle roomId into session-specific data](https://github.com/HexaBrawl/app/issues/70)

- [STOMP-Pfade in den Methoden neu ausrichten](https://github.com/HexaBrawl/app/issues/69)
  - Functions now use roomId in stomp paths as was described in the criteria.
  - Implemented [review change request](https://github.com/HexaBrawl/app/pull/80#issuecomment-4584199395), branch should now be in line with API contract. 

- [Tests in UnitMoveEndpointTest auf room-scoped Mocks angepasst](https://github.com/HexaBrawl/app/issues/74)
  - Tests where updated to the new function parameters and adjusted to check the path for the roomId.

- Closed [previous PR](https://github.com/HexaBrawl/app/pull/80) due to issues with branch structure. Sub issues are now hosted in their own branch that will be merged into a issue branch instead of main.