### PR TITLE
Refactoring HomeScreen to MVVM and disable dependency verification

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,7 +101,7 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         // Composables / UI-Screens (HexaBrawl UI)
         "**/ui/components/**",
         "**/ui/game/GameScreen*.*",
-        "**/ui/lobby/HomeScreen*.*",
+        "**/ui/home/HomeScreen*.*",
         "**/ui/lobby_modes/ActionCard*.*",
         "**/ui/lobby_modes/JoinByCodeDialog*.*",
         "**/ui/lobby_modes/LobbyScreen*.*",

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/home/HomeScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/home/HomeScreen.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.websocketbrokerdemo.ui.lobby
+package at.aau.serg.websocketbrokerdemo.ui.home
 
 import android.app.Activity
 import androidx.compose.foundation.Image
@@ -9,32 +9,25 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cancel
-import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -46,26 +39,27 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import at.aau.serg.websocketbrokerdemo.audio.MusicManager
-import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoin
 import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinDark
 import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinLight
-import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
-import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentBase
-import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentDark
 import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentLight
 import at.aau.serg.websocketbrokerdemo.ui.theme.WoodDark
 import at.aau.serg.websocketbrokerdemo.ui.theme.WoodLight
 import at.aau.serg.websocketbrokerdemo.ui.theme.WoodMedium
 import com.example.myapplication.R
 
+/**
+ * HomeScreen -- der Startbildschirm der App.
+ *
+ * Reine UI-Schicht. Sämtliche Logik (Musik starten, Navigation, Exit)
+ * liegt in [HomeScreenLogic] und ist dort getestet.
+ */
 @Composable
 fun HomeScreen(navController: NavController) {
     val context = LocalContext.current
     val activity = context as? Activity
 
     LaunchedEffect(Unit) {
-        MusicManager.playMenuMusic(context)
+        HomeScreenLogic.startMenuMusic(context)
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -87,9 +81,7 @@ fun HomeScreen(navController: NavController) {
             painter = painterResource(id = R.drawable.bg_homescreen),
             contentDescription = null,
             contentScale = ContentScale.FillBounds,
-            modifier = Modifier
-                .fillMaxSize()
-
+            modifier = Modifier.fillMaxSize()
         )
 
         // 3) Sanfte Vignette
@@ -109,7 +101,7 @@ fun HomeScreen(navController: NavController) {
 
         // 4) Settings-Button oben
         IconButton(
-            onClick = { navController.navigate("settings") },
+            onClick = { HomeScreenLogic.onSettingsClicked(navController) },
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .padding(156.dp)
@@ -135,30 +127,24 @@ fun HomeScreen(navController: NavController) {
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(bottom = 10.dp)
-                //.offset(x = 20.dp)
                 .size(300.dp)
         ) {
             Button(
-                onClick = {
-                    navigateSafe(navController, primary = "mainmenu", fallback = "game")
-                },
+                onClick = { HomeScreenLogic.onPlayClicked(navController) },
                 shape = CircleShape,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Color.Transparent,
                     contentColor = Color.Unspecified
                 ),
-                modifier = Modifier.fillMaxSize() ,
+                modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(0.dp)
             ) {
-
-                    // 2. Das eigentliche Icon
-                    Icon(
-                        painter = painterResource(id = R.drawable.playbutton),
-                        contentDescription = "Play",
-                        modifier = Modifier.fillMaxSize(),
-                        tint = Color.Unspecified
-                    )
-               // }
+                Icon(
+                    painter = painterResource(id = R.drawable.playbutton),
+                    contentDescription = "Play",
+                    modifier = Modifier.fillMaxSize(),
+                    tint = Color.Unspecified
+                )
             }
         }
 
@@ -178,7 +164,7 @@ fun HomeScreen(navController: NavController) {
                 .border(2.dp, GoldCoinDark, RoundedCornerShape(8.dp))
         ) {
             Button(
-                onClick = { activity?.finish() },
+                onClick = { HomeScreenLogic.exitApp(activity) },
                 shape = RoundedCornerShape(8.dp),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Color.Transparent,
@@ -205,10 +191,4 @@ fun HomeScreen(navController: NavController) {
             }
         }
     }
-}
-
-private fun navigateSafe(navController: NavController, primary: String, fallback: String) {
-    val graph = navController.graph
-    val hasPrimary = graph.any { it.route == primary }
-    navController.navigate(if (hasPrimary) primary else fallback)
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/home/HomeScreenLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/home/HomeScreenLogic.kt
@@ -1,0 +1,63 @@
+package at.aau.serg.websocketbrokerdemo.ui.home
+
+import android.app.Activity
+import android.content.Context
+import androidx.navigation.NavController
+import at.aau.serg.websocketbrokerdemo.audio.MusicManager
+
+/**
+ * Bündelt die Logik des HomeScreens.
+ *
+ * Hält keinen eigenen State -- der HomeScreen ist stateless, deshalb keine
+ * ViewModel-Anbindung. Diese Klasse extrahiert nur die Side-Effects und
+ * Navigation-Logik aus dem Composable, damit sie testbar wird.
+ *
+ * Verantwortungen:
+ *  - Menü-Musik starten
+ *  - Sichere Navigation zum Hauptmenü (mit Fallback)
+ *  - App beenden
+ */
+object HomeScreenLogic {
+
+    /** Startet die Menü-Musik. */
+    fun startMenuMusic(context: Context) {
+        MusicManager.playMenuMusic(context)
+    }
+
+    /**
+     * Versucht zur primären Route zu navigieren. Falls die noch nicht im
+     * NavGraph registriert ist (z. B. weil das Hauptmenü-Composable in
+     * einem späteren Task hinzukommt), wird der Fallback genutzt.
+     *
+     * Zentrale Stelle für diese Logik -- vorher war sie als private fun
+     * im HomeScreen-File und nicht testbar.
+     */
+    fun navigateSafe(navController: NavController, primary: String, fallback: String) {
+        val target = if (hasRoute(navController, primary)) primary else fallback
+        navController.navigate(target)
+    }
+
+    /** Prüft ob eine Route im NavGraph existiert. */
+    fun hasRoute(navController: NavController, route: String): Boolean =
+        navController.graph.any { it.route == route }
+
+    /**
+     * Beendet die App. Wenn der Context keine Activity ist (z. B. Preview-
+     * Mode oder Test), passiert nichts -- darf nicht crashen.
+     */
+    fun exitApp(activity: Activity?) {
+        activity?.finish()
+    }
+
+    /**
+     * Convenience: Klick auf PLAY -> ins Hauptmenü, sonst Fallback auf "game".
+     */
+    fun onPlayClicked(navController: NavController) {
+        navigateSafe(navController, primary = "mainmenu", fallback = "game")
+    }
+
+    /** Convenience: Klick auf Settings. */
+    fun onSettingsClicked(navController: NavController) {
+        navController.navigate("settings")
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/navigation/AppNavHost.kt
@@ -11,7 +11,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import at.aau.serg.websocketbrokerdemo.audio.MusicManager
 import at.aau.serg.websocketbrokerdemo.network.GameSession
 import at.aau.serg.websocketbrokerdemo.ui.game.GameScreen
-import at.aau.serg.websocketbrokerdemo.ui.lobby.HomeScreen
+import at.aau.serg.websocketbrokerdemo.ui.home.HomeScreen
 import at.aau.serg.websocketbrokerdemo.ui.lobby_modes.LobbyScreen
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.MainMenuScreen

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/home/HomeScreenLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/home/HomeScreenLogicTest.kt
@@ -1,0 +1,196 @@
+package at.aau.serg.websocketbrokerdemo.ui.home
+
+import android.app.Activity
+import android.content.Context
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.NavGraph
+import at.aau.serg.websocketbrokerdemo.audio.MusicManager
+import at.aau.serg.websocketbrokerdemo.ui.home.HomeScreenLogic
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests für HomeScreenLogic.
+ *
+ * HomeScreenLogic ist ein object ohne eigenen State -- jeder Aufruf
+ * delegiert direkt an MusicManager bzw. NavController. Wir testen vor allem:
+ *
+ *  - Routing-Verzweigungen (hasRoute, navigateSafe mit Fallback)
+ *  - Korrekte Forwards an die Singletons / NavController
+ *  - Null-Safety bei der Activity (exitApp)
+ *
+ * Mocking:
+ *  - NavController + NavGraph -> normale Mocks. Den NavGraph müssen wir
+ *    sorgfältig nachbilden, weil hasRoute() darüber iteriert.
+ *  - MusicManager ist ein object -> mockkObject
+ */
+class HomeScreenLogicTest {
+
+    private lateinit var navController: NavController
+    private lateinit var navGraph: NavGraph
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(MusicManager)
+        navController = mockk(relaxed = true)
+        navGraph = mockk(relaxed = true)
+        every { navController.graph } returns navGraph
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // -------------------------------------------------------------------------
+    // startMenuMusic()
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `startMenuMusic delegates to MusicManager`() {
+        // Reines Forwarding: HomeScreen.LaunchedEffect ruft das auf, hier
+        // prüfen wir nur dass der MusicManager wirklich angestoßen wird.
+        val context = mockk<Context>(relaxed = true)
+
+        HomeScreenLogic.startMenuMusic(context)
+
+        verify { MusicManager.playMenuMusic(context) }
+    }
+
+    // -------------------------------------------------------------------------
+    // hasRoute()
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `hasRoute returns true when route exists in graph`() {
+        // hasRoute() iteriert über den NavGraph und sucht nach destination.route.
+        // Wir bauen einen NavGraph mit einem Eintrag und prüfen das Matching.
+        val destination = mockk<NavDestination>()
+        every { destination.route } returns "settings"
+        every { navGraph.iterator() } returns mutableListOf(destination).iterator()
+
+        assertTrue(HomeScreenLogic.hasRoute(navController, "settings"))
+    }
+
+    @Test
+    fun `hasRoute returns false when route is missing`() {
+        // Edge-Case: NavGraph enthält andere Routen, aber nicht die gesuchte.
+        val destination = mockk<NavDestination>()
+        every { destination.route } returns "home"
+        every { navGraph.iterator() } returns mutableListOf(destination).iterator()
+
+        assertFalse(HomeScreenLogic.hasRoute(navController, "settings"))
+    }
+
+    @Test
+    fun `hasRoute returns false for empty navigation graph`() {
+        // Robustheit: leerer Graph darf nicht crashen.
+        every { navGraph.iterator() } returns mutableListOf<NavDestination>().iterator()
+
+        assertFalse(HomeScreenLogic.hasRoute(navController, "anything"))
+    }
+
+    // -------------------------------------------------------------------------
+    // navigateSafe()
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `navigateSafe uses primary route when it exists`() {
+        // Happy-Path: primary ist im NavGraph registriert -> dahin navigieren.
+        val destination = mockk<NavDestination>()
+        every { destination.route } returns "mainmenu"
+        every { navGraph.iterator() } returns mutableListOf(destination).iterator()
+
+        HomeScreenLogic.navigateSafe(navController, primary = "mainmenu", fallback = "game")
+
+        verify { navController.navigate("mainmenu") }
+        verify(exactly = 0) { navController.navigate("game") }
+    }
+
+    @Test
+    fun `navigateSafe falls back when primary route is missing`() {
+        // Während der Entwicklung kann das Hauptmenü-Composable noch fehlen --
+        // dann soll der Fallback (z. B. direkt "game") greifen, damit der
+        // PLAY-Button nicht crasht.
+        val destination = mockk<NavDestination>()
+        every { destination.route } returns "game"  // nur "game" registriert
+        every { navGraph.iterator() } returns mutableListOf(destination).iterator()
+
+        HomeScreenLogic.navigateSafe(navController, primary = "mainmenu", fallback = "game")
+
+        verify { navController.navigate("game") }
+        verify(exactly = 0) { navController.navigate("mainmenu") }
+    }
+
+    // -------------------------------------------------------------------------
+    // exitApp()
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `exitApp calls finish on the activity`() {
+        // Normalfall: User drückt Exit -> Activity wird beendet.
+        val activity = mockk<Activity>(relaxed = true)
+        justRun { activity.finish() }
+
+        HomeScreenLogic.exitApp(activity)
+
+        verify { activity.finish() }
+    }
+
+    @Test
+    fun `exitApp handles null activity gracefully`() {
+        // Wichtig: in Compose-Previews oder Tests ist der LocalContext
+        // manchmal keine Activity -> activity ist null. Darf NICHT crashen.
+        HomeScreenLogic.exitApp(null)
+        // Kein verify -- der Test prüft nur dass keine Exception fliegt.
+    }
+
+    // -------------------------------------------------------------------------
+    // Convenience: onPlayClicked / onSettingsClicked
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onPlayClicked navigates to mainmenu when available`() {
+        val destination = mockk<NavDestination>()
+        every { destination.route } returns "mainmenu"
+        every { navGraph.iterator() } returns mutableListOf(destination).iterator()
+
+        HomeScreenLogic.onPlayClicked(navController)
+
+        verify { navController.navigate("mainmenu") }
+    }
+
+    @Test
+    fun `onPlayClicked falls back to game when mainmenu missing`() {
+        // Dokumentiert den Fallback-Pfad für den PLAY-Button:
+        // Wenn das Hauptmenü-Composable noch nicht da ist, springt der Spieler
+        // direkt ins Spiel statt zu crashen.
+        val destination = mockk<NavDestination>()
+        every { destination.route } returns "game"
+        every { navGraph.iterator() } returns mutableListOf(destination).iterator()
+
+        HomeScreenLogic.onPlayClicked(navController)
+
+        verify { navController.navigate("game") }
+    }
+
+    @Test
+    fun `onSettingsClicked navigates to settings route`() {
+        // Settings-Route existiert immer (kein Fallback nötig), daher
+        // direkter navigate-Aufruf.
+        HomeScreenLogic.onSettingsClicked(navController)
+
+        verify { navController.navigate("settings") }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ sonar {
                 // Composables / UI-Screens
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/components/**",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt",
-                "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby/HomeScreen.kt",
+                "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/home/HomeScreen.kt",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/ActionCard.kt",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/JoinByCodeDialog.kt",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt",

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,4 @@ android.newDsl=false
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 #android.nonTransitiveRClass=true
+org.gradle.dependency.verification=off


### PR DESCRIPTION
## Summary📝 

In this update, I cleaned up the HomeScreen and moved all non‑UI behavior into a dedicated HomeScreenLogic class.
The screen is now fully stateless and only responsible for rendering UI, while all side‑effects and navigation logic are handled outside the composable.

### Here’s what was changed:

- Replaced all direct calls inside the composable (navigateSafe, activity.finish(), MusicManager.playMenuMusic()) with the corresponding methods from HomeScreenLogic.

- Removed the old navigateSafe() helper from the HomeScreen file since the logic now lives in one central place.

- Updated the package structure (ui.lobby → ui.home) so the HomeScreen sits in the correct module.

- Adjusted the import in AppNavHost to point to the new HomeScreen location.

- Cleaned up duplicate modifiers and leftover code fragments.

- Ensured that the HomeScreen no longer contains any logic, just UI, making it easier to maintain and test.

- Disabled dependency verification so that verification-metadata wont be produced

The result is a much cleaner HomeScreen with a clear separation between UI and logic, and all behavior is now testable through HomeScreenLogicTest.