### PR TITLE
Refactor network layer - Phase 2

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -45,15 +45,10 @@ class MainActivity : ComponentActivity() {
             MusicManager.applySfxSettings(s.sfxEnabled)
         }
 
-        // Connect STOMP once for the whole app session; then wire the two
-        // server-side streams into the shared GameSession state.
+        // Connect STOMP once for the whole app session; then wire the error stream.
         lifecycleScope.launch {
             try {
                 stomp.connect()
-                endpoint.subscribeToGameState(session.roomId.value) { state ->
-                    session.gameState.value = state
-                    session.gameStateReceivedCount.intValue += 1
-                }
                 endpoint.subscribeToErrors { err ->
                     Log.w(TAG, "Server error: ${err.errorCode} - ${err.message}")
                     session.lastError.value = err

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
@@ -20,7 +20,7 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.GameState
  */
 class GameSession(
     val endpoint: UnitMoveEndpoint,
-    val roomId: MutableState<String> = mutableStateOf("game1"),
+    val activeRoomId: MutableState<String> = mutableStateOf("game1"),
     val gameState: MutableState<GameState?> = mutableStateOf(null),
     val lastError: MutableState<ErrorMessage?> = mutableStateOf(null),
     val localPlayerName: MutableState<String?> = mutableStateOf(null),

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
@@ -17,7 +17,7 @@ import org.hildan.krossbow.websocket.okhttp.OkHttpWebSocketClient
  * Single STOMP entry-point for the whole app.
  *
  * NOTE on content-type:
- *  - sendText  -> "text/plain"        (for /app/join, /app/init)
+ *  - sendText  -> "text/plain"        (for /app/join)
  *  - sendJson  -> "application/json"  (for /app/move - Spring deserializes to DTO)
  * The default `sendText` extension of Krossbow would send everything as text/plain,
  * which prevents Spring's Jackson converter from mapping the payload to a `Move` DTO.

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
@@ -5,35 +5,13 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.ErrorMessage
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameState
 import at.aau.serg.websocketbrokerdemo.data.serverside.Move
 import com.google.gson.Gson
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-
-/**
- * Workaround toggle for the deployed (Azure) backend.
- *
- * `WebSocketBrokerController.move()` on the server checks
- * `stateAfter === stateBefore` to detect rejected moves, but both references
- * point to the same singleton `GameState`, so the check is always true. The
- * controller therefore never broadcasts the result of a successful move.
- *
- * Until the server is redeployed with the fix, the client re-fetches the state
- * via `/app/init` shortly after every move so the UI catches up.
- *
- * Set this to false once the fixed server is in production.
- */
-private const val AZURE_MOVE_BROADCAST_WORKAROUND = true
-private const val POST_MOVE_REFRESH_DELAY_MS = 150L
 
 class UnitMoveEndpoint(
     private val stomp: Stomp
 ) {
 
     private val gson = Gson()
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     fun subscribeToGameState(roomId: String, onGameState: (GameState) -> Unit): Job =
         stomp.subscribe("/topic/rooms/$roomId/state") { msg ->
@@ -60,13 +38,6 @@ class UnitMoveEndpoint(
             val json = gson.toJson(move)
             Log.d(TAG, "-> /app/rooms/$roomId/move: $json")
             stomp.sendJson("/app/rooms/$roomId/move", json)
-
-            if (AZURE_MOVE_BROADCAST_WORKAROUND) {
-                scope.launch {
-                    delay(POST_MOVE_REFRESH_DELAY_MS)
-                    requestInitialState(roomId)
-                }
-            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed sending move", e)
         }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
@@ -48,11 +48,6 @@ class UnitMoveEndpoint(
         stomp.sendText("/app/rooms/$roomId/join", playerName)
     }
 
-    fun requestInitialState(roomId: String) {
-        Log.d(TAG, "-> /app/rooms/$roomId/init/")
-        stomp.sendText("/app/rooms/$roomId/init/", "")
-    }
-
     companion object {
         private const val TAG = "UnitMoveEndpoint"
     }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -65,7 +65,7 @@ fun GameScreen(
     var lastMove by remember { mutableStateOf<String>("-") }
 
     LaunchedEffect(Unit) {
-        if (gameState == null) session.endpoint.requestInitialState(session.roomId.value)
+        if (gameState == null) session.endpoint.requestInitialState(session.activeRoomId.value)
     }
 
     LaunchedEffect(gameState?.currentTurn, gameState?.status, botName) {
@@ -76,7 +76,7 @@ fun GameScreen(
 
         delay(800)
         val move = pickBotMove(state, bot)
-        if (move != null) session.endpoint.sendMove(session.roomId.value, move)
+        if (move != null) session.endpoint.sendMove(session.activeRoomId.value, move)
     }
 
     val units: List<GameUnit> = gameState?.units.orEmpty()
@@ -136,7 +136,7 @@ fun GameScreen(
                 )
                 lastMove = "${current.type} (${current.x},${current.y}) -> ($col,$row)"
                 session.lastError.value = null
-                session.endpoint.sendMove(session.roomId.value, move)
+                session.endpoint.sendMove(session.activeRoomId.value, move)
                 selected = null
             }
         }
@@ -250,7 +250,7 @@ fun GameScreen(
                 modifier = Modifier.padding(top = 4.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Button(onClick = { session.endpoint.requestInitialState(session.roomId.value) }) {
+                Button(onClick = { session.endpoint.requestInitialState(session.activeRoomId.value) }) {
                     Text("Refresh /app/init")
                 }
                 Button(onClick = { session.lastError.value = null }) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -64,6 +64,16 @@ fun GameScreen(
     var lastTap by remember { mutableStateOf<String>("-") }
     var lastMove by remember { mutableStateOf<String>("-") }
 
+    DisposableEffect(session.activeRoomId.value) {
+        val job = session.endpoint.subscribeToGameState(session.activeRoomId.value) { state ->
+            session.gameState.value = state
+            session.gameStateReceivedCount.intValue += 1
+        }
+        onDispose {
+            job.cancel()
+        }
+    }
+
     LaunchedEffect(Unit) {
         if (gameState == null) session.endpoint.requestInitialState(session.activeRoomId.value)
     }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -74,9 +74,6 @@ fun GameScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        if (gameState == null) session.endpoint.requestInitialState(session.activeRoomId.value)
-    }
 
     LaunchedEffect(gameState?.currentTurn, gameState?.status, botName) {
         val state = gameState ?: return@LaunchedEffect
@@ -260,9 +257,6 @@ fun GameScreen(
                 modifier = Modifier.padding(top = 4.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Button(onClick = { session.endpoint.requestInitialState(session.activeRoomId.value) }) {
-                    Text("Refresh /app/init")
-                }
                 Button(onClick = { session.lastError.value = null }) {
                     Text("Clear error")
                 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
@@ -106,6 +106,16 @@ fun SyncLobbyWithServer(
     val localSlot = slots.firstOrNull { it.isLocal } ?: return
     val localName = localSlot.name
 
+    DisposableEffect(session.activeRoomId.value) {
+        val job = session.endpoint.subscribeToGameState(session.activeRoomId.value) { state ->
+            session.gameState.value = state
+            session.gameStateReceivedCount.intValue += 1
+        }
+        onDispose {
+            job.cancel()
+        }
+    }
+
     LaunchedEffect(localName) {
         session.localPlayerName.value = localName
         session.endpoint.joinGame(session.activeRoomId.value, localName)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
@@ -108,7 +108,7 @@ fun SyncLobbyWithServer(
 
     LaunchedEffect(localName) {
         session.localPlayerName.value = localName
-        session.endpoint.joinGame(session.roomId.value, localName)
+        session.endpoint.joinGame(session.activeRoomId.value, localName)
     }
 
     // Dev shortcut: if after a few seconds the backend still only has us,
@@ -122,7 +122,7 @@ fun SyncLobbyWithServer(
             if (!alreadyHasPartner && session.botPlayerName.value == null) {
                 val botName = "Bot-" + GENERAL_NAMES.random().substringAfter(' ')
                 session.botPlayerName.value = botName
-                session.endpoint.joinGame(session.roomId.value, botName)
+                session.endpoint.joinGame(session.activeRoomId.value, botName)
             }
         }
     }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
@@ -54,15 +54,6 @@ class UnitMoveEndpointTest {
         }
     }
 
-    @Test
-    fun `requestInitialState sends empty init message`() {
-
-        endpoint.requestInitialState("game1")
-
-        verify {
-            stomp.sendText("/app/rooms/game1/init/", "")
-        }
-    }
 
     @Test
     fun `subscribeToGameState parses GameState correctly`() {


### PR DESCRIPTION
Continued working on [Feature "Refactor Network Layer"](https://github.com/HexaBrawl/app/issues/65) and implemented:

- [Subscription-Lifecycle: MainActivity subscribed nur noch errors](https://github.com/HexaBrawl/app/issues/71)
  - Removed Game State subscription from MainActivity and moved it into WaitingLobbyState

- [AZURE_MOVE_BROADCAST_WORKAROUND + zugehöriger Auto-Init-Code entfernen](https://github.com/HexaBrawl/app/issues/72)
  - Removed Workaround val and all related clauses from Endpoint
  - Removed RequestInitialState fun from Endpoint and disconnected all fun uses 