### PR TITLE
Refactoring lobby modes

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/JoinByCodeDialog.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/JoinByCodeDialog.kt
@@ -16,10 +16,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -43,20 +39,18 @@ import com.example.myapplication.R
 /**
  * Pergament-Dialog zum Beitreten einer Lobby per Code.
  *
- * Der Composable ist auf reine UI reduziert -- die Logik (Eingabe-
- * Normalisierung und Gueltigkeits-Pruefung) liegt in [JoinByCodeLogic]
- * und ist dort unit-getestet. Hier wird die normalize-Funktion bei
- * jedem Tastendruck angewandt, damit der TextField-Inhalt stets in
- * einem gueltigen Format ist.
+ * Stateless: code, canJoin und alle Handler kommen von aussen (aus dem
+ * [LobbyViewModel]). Damit haelt der Dialog selbst nichts und ist
+ * komplett von der UI-Schicht abgekoppelt.
  */
 @Composable
 fun JoinByCodeDialog(
+    code: String,
+    canJoin: Boolean,
+    onCodeChange: (String) -> Unit,
     onDismiss: () -> Unit,
-    onJoin: (String) -> Unit
+    onJoin: () -> Unit
 ) {
-    var code by remember { mutableStateOf("") }
-    val canJoin = JoinByCodeLogic.isValid(code)
-
     Dialog(onDismissRequest = onDismiss) {
         Box(
             modifier = Modifier
@@ -90,9 +84,7 @@ fun JoinByCodeDialog(
 
                 OutlinedTextField(
                     value = code,
-                    onValueChange = { input ->
-                        code = JoinByCodeLogic.normalize(input)
-                    },
+                    onValueChange = onCodeChange,
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Characters
@@ -125,7 +117,7 @@ fun JoinByCodeDialog(
                     DialogButton(
                         text = stringResource(R.string.dialog_join),
                         primary = canJoin,
-                        onClick = { if (canJoin) onJoin(code) }
+                        onClick = onJoin
                     )
                 }
             }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt
@@ -15,9 +15,6 @@ import androidx.compose.material.icons.filled.GroupAdd
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -26,6 +23,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import at.aau.serg.websocketbrokerdemo.ui.components.PlayerCountBadge
 import at.aau.serg.websocketbrokerdemo.ui.components.RoundCoinIconButton
@@ -38,18 +37,16 @@ import com.example.myapplication.R
  * Modus-Lobby: Auswahl zwischen "Privates Spiel erstellen", "Mit Code
  * beitreten" und "Zufaelliges Spiel".
  *
- * Reine UI-Schicht. Sammelt nur den `showJoinDialog`-State lokal
- * (kein dediziertes ViewModel, weil es um genau ein Boolean ohne
- * Persistierung geht). Navigation laeuft ueber [LobbyLogic.toWaitingScreen]
- * und das type-safe [Screen]-Konstrukt.
+ * Reine UI-Schicht. State und Dialog-Handler liegen im
+ * [LobbyViewModel]; Navigation-Mapping in [LobbyLogic].
  */
 @Composable
 fun LobbyScreen(
     mode: GameMode,
-    navController: NavController
+    navController: NavController,
+    viewModel: LobbyViewModel = viewModel()
 ) {
-    var showJoinDialog by remember { mutableStateOf(false) }
-
+    val state by viewModel.state.collectAsStateWithLifecycle()
     val waitingScreen = LobbyLogic.toWaitingScreen(mode)
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -121,7 +118,7 @@ fun LobbyScreen(
                 title = stringResource(R.string.lobby_join_with_code),
                 subtitle = stringResource(R.string.lobby_join_with_code_sub),
                 sealColor = SealColor.Blue,
-                onClick = { showJoinDialog = true }
+                onClick = { viewModel.openJoinDialog() }
             )
             ActionCard(
                 icon = Icons.Filled.Casino,
@@ -133,12 +130,16 @@ fun LobbyScreen(
         }
     }
 
-    if (showJoinDialog) {
+    if (state.showJoinDialog) {
         JoinByCodeDialog(
-            onDismiss = { showJoinDialog = false },
+            code = state.code,
+            canJoin = state.canJoin,
+            onCodeChange = viewModel::onCodeChange,
+            onDismiss = viewModel::closeJoinDialog,
             onJoin = {
-                showJoinDialog = false
-                navController.navigate(waitingScreen.route)
+                if (viewModel.tryJoinByCode()) {
+                    navController.navigate(waitingScreen.route)
+                }
             }
         )
     }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyState.kt
@@ -1,0 +1,21 @@
+package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
+
+/**
+ * UI-State der Modus-Lobby.
+ *
+ * Vom [LobbyViewModel] ueber einen StateFlow exponiert. Der
+ * [LobbyScreen] liest ausschliesslich diesen State und ruft
+ * Handler-Methoden des ViewModels auf -- keine `remember`-State-
+ * Verwaltung im Composable.
+ *
+ *  - [showJoinDialog] Ob der "Mit Code beitreten"-Dialog gerade sichtbar ist
+ *  - [code]           Aktueller Inhalt des Code-Eingabefelds (normalisiert)
+ */
+data class LobbyState(
+    val showJoinDialog: Boolean = false,
+    val code: String = ""
+) {
+    /** True wenn der aktuelle Code gueltig ist (4-8 Zeichen). */
+    val canJoin: Boolean
+        get() = JoinByCodeLogic.isValid(code)
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
@@ -1,0 +1,63 @@
+package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * ViewModel der Modus-Lobby.
+ *
+ * Haelt den UI-State (Dialog-Sichtbarkeit, Code-Eingabe) und stellt
+ * Handler fuer die drei Lobby-Aktionen bereit. Die eigentliche
+ * Navigation laeuft nicht durch das ViewModel -- die Aufrufer-Seite
+ * (LobbyScreen) navigiert mit dem NavController, sobald das ViewModel
+ * signalisiert "joinen ok". So bleibt das ViewModel frei von Compose-
+ * Navigation-Abhaengigkeiten und ist sauber unit-testbar.
+ *
+ * Da der Dialog-State (Code-Eingabe) im ViewModel lebt statt im
+ * Composable, wird er beim Wiederoeffnen des Dialogs aktiv geleert --
+ * siehe [openJoinDialog] und [closeJoinDialog].
+ */
+class LobbyViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow(LobbyState())
+
+    /** Public State, vom Composable ueber collectAsStateWithLifecycle gelesen. */
+    val state: StateFlow<LobbyState> = _state.asStateFlow()
+
+    // ---- Dialog-Lifecycle ----------------------------------------------
+
+    /** Oeffnet den "Beitreten via Code"-Dialog mit leerem Eingabefeld. */
+    fun openJoinDialog() {
+        _state.value = LobbyState(showJoinDialog = true, code = "")
+    }
+
+    /** Schliesst den Dialog ohne weitere Aktion (Cancel). */
+    fun closeJoinDialog() {
+        _state.value = _state.value.copy(showJoinDialog = false)
+    }
+
+    // ---- Code-Eingabe --------------------------------------------------
+
+    /**
+     * Verarbeitet eine Code-Eingabe. Wendet [JoinByCodeLogic.normalize]
+     * an, damit der State stets in einem gueltigen Format bleibt.
+     */
+    fun onCodeChange(rawInput: String) {
+        _state.value = _state.value.copy(code = JoinByCodeLogic.normalize(rawInput))
+    }
+
+    // ---- Beitritts-Aktionen --------------------------------------------
+
+    /**
+     * Versucht beizutreten. Liefert true, wenn der Code gueltig ist und
+     * der Aufrufer (Screen) navigieren darf. Im Erfolgsfall wird der
+     * Dialog automatisch geschlossen.
+     */
+    fun tryJoinByCode(): Boolean {
+        if (!_state.value.canJoin) return false
+        _state.value = _state.value.copy(showJoinDialog = false)
+        return true
+    }
+}

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyStateTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyStateTest.kt
@@ -1,0 +1,48 @@
+package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests fuer LobbyState.
+ *
+ * Defaults und die computed `canJoin`-Property. Die zugrundeliegende
+ * Validierungs-Logik (JoinByCodeLogic.isValid) ist separat in
+ * JoinByCodeLogicTest abgedeckt; hier nur sanity-checks dass der
+ * State sie richtig verkabelt.
+ */
+class LobbyStateTest {
+
+    @Test
+    fun `default state has dialog closed and empty code`() {
+        val state = LobbyState()
+        assertFalse(state.showJoinDialog)
+        assertEquals("", state.code)
+    }
+
+    @Test
+    fun `canJoin is false for empty code`() {
+        val state = LobbyState(code = "")
+        assertFalse(state.canJoin)
+    }
+
+    @Test
+    fun `canJoin is false for short code`() {
+        val state = LobbyState(code = "ABC")
+        assertFalse(state.canJoin)
+    }
+
+    @Test
+    fun `canJoin is true for valid 4-character code`() {
+        val state = LobbyState(code = "ABCD")
+        assertTrue(state.canJoin)
+    }
+
+    @Test
+    fun `canJoin is true for valid 8-character code`() {
+        val state = LobbyState(code = "ABCDEFGH")
+        assertTrue(state.canJoin)
+    }
+}

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModelTest.kt
@@ -1,0 +1,116 @@
+package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests fuer LobbyViewModel.
+ *
+ * Reine State-Maschine ohne Coroutines, daher kein Coroutine-Setup
+ * noetig. Geprueft werden Dialog-Lifecycle, Code-Eingabe und der
+ * Join-Versuch mit gueltigem/ungueltigem Code.
+ */
+class LobbyViewModelTest {
+
+    private lateinit var vm: LobbyViewModel
+
+    @BeforeEach
+    fun setUp() {
+        vm = LobbyViewModel()
+    }
+
+    // ---- Initialer State -----------------------------------------------
+
+    @Test
+    fun `initial state has dialog closed and empty code`() {
+        val state = vm.state.value
+        assertFalse(state.showJoinDialog)
+        assertEquals("", state.code)
+        assertFalse(state.canJoin)
+    }
+
+    // ---- Dialog-Lifecycle ----------------------------------------------
+
+    @Test
+    fun `openJoinDialog sets showJoinDialog to true`() {
+        vm.openJoinDialog()
+        assertTrue(vm.state.value.showJoinDialog)
+    }
+
+    @Test
+    fun `openJoinDialog resets the code field`() {
+        // Wenn der User schon mal getippt hat und den Dialog wieder
+        // oeffnet, darf der alte Inhalt nicht stehenbleiben.
+        vm.onCodeChange("ABCD")
+        vm.closeJoinDialog()
+        vm.openJoinDialog()
+        assertEquals("", vm.state.value.code)
+    }
+
+    @Test
+    fun `closeJoinDialog sets showJoinDialog to false`() {
+        vm.openJoinDialog()
+        vm.closeJoinDialog()
+        assertFalse(vm.state.value.showJoinDialog)
+    }
+
+    // ---- Code-Eingabe --------------------------------------------------
+
+    @Test
+    fun `onCodeChange normalizes the input`() {
+        vm.onCodeChange("ab cd 12!")
+        assertEquals("ABCD12", vm.state.value.code)
+    }
+
+    @Test
+    fun `onCodeChange caps at 8 characters`() {
+        vm.onCodeChange("ABCDEFGHIJKL")
+        assertEquals(8, vm.state.value.code.length)
+        assertEquals("ABCDEFGH", vm.state.value.code)
+    }
+
+    @Test
+    fun `onCodeChange to empty string clears the code`() {
+        vm.onCodeChange("ABCD")
+        vm.onCodeChange("")
+        assertEquals("", vm.state.value.code)
+    }
+
+    // ---- tryJoinByCode -------------------------------------------------
+
+    @Test
+    fun `tryJoinByCode returns false for invalid code`() {
+        vm.openJoinDialog()
+        vm.onCodeChange("AB")    // zu kurz
+        val result = vm.tryJoinByCode()
+        assertFalse(result)
+        // Dialog bleibt offen, der User soll seinen Code korrigieren koennen
+        assertTrue(vm.state.value.showJoinDialog)
+    }
+
+    @Test
+    fun `tryJoinByCode returns true for valid code and closes dialog`() {
+        vm.openJoinDialog()
+        vm.onCodeChange("ABCD")
+        val result = vm.tryJoinByCode()
+        assertTrue(result)
+        assertFalse(vm.state.value.showJoinDialog)
+    }
+
+    @Test
+    fun `tryJoinByCode returns false when code is empty`() {
+        vm.openJoinDialog()
+        val result = vm.tryJoinByCode()
+        assertFalse(result)
+    }
+
+    @Test
+    fun `tryJoinByCode succeeds at 8 character boundary`() {
+        vm.openJoinDialog()
+        vm.onCodeChange("ABCDEFGH")
+        assertTrue(vm.tryJoinByCode())
+    }
+}


### PR DESCRIPTION
## Lobby-Screen vollständig auf MVVM umgestellt.

### Neu:
- LobbyViewModel: hält State (Dialog-Sichtbarkeit, Code-Eingabe) und
  alle Click-Handler
- LobbyState: data class mit computed canJoin

### Geändert:
- LobbyScreen: keine remember-State-Verwaltung mehr, keine inline-Logik
- JoinByCodeDialog: jetzt stateless, bekommt code/canJoin/Handler als
  Parameter

### Tests: 
LobbyStateTest, LobbyViewModelTest.