### PR TITLE
Logic layer für lobby room

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/RoomDTO.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/RoomDTO.kt
@@ -11,4 +11,7 @@ data class RoomDTO(
     val joinCode: String,
     val mode: GameMode,
     val players: List<Player>
-)
+) {
+    /** Alias fuer LobbyRoomLogic, die roomId erwartet. */
+    val roomId: String get() = joinCode
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyEffect.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyEffect.kt
@@ -1,0 +1,28 @@
+package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
+
+/**
+ * Beschreibt eine einzelne State-Mutation, die das [LobbyViewModel]
+ * nach einer Lobby-Room-Aktion durchfuehren soll.
+ *
+ * Wird von [LobbyRoomLogic] aus einem Server-Ergebnis berechnet -- das
+ * ViewModel selbst trifft keine fachlichen Entscheidungen mehr, sondern
+ * dispatched nur noch jeden Effect 1:1 auf einen State-Setter. Damit
+ * landet die gesamte Logik in einem testbaren, seiteneffekt-freien
+ * Object.
+ *
+ * Pattern: Unidirectional Data Flow / Effect-Pattern, vergleichbar mit
+ * Elm-Cmd oder Spotify-Mobius.
+ */
+sealed interface LobbyEffect {
+    /** Aktive Room-Id der GameSession setzen. */
+    data class SetRoomId(val roomId: String) : LobbyEffect
+
+    /** Eine Fehlermeldung im UI anzeigen. */
+    data class ShowError(val message: String) : LobbyEffect
+
+    /** Den "Beitreten via Code"-Dialog schliessen. */
+    data object CloseJoinDialog : LobbyEffect
+
+    /** Zur WaitingLobby navigieren (loest den onSuccess-Callback aus). */
+    data object NavigateToWaiting : LobbyEffect
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogic.kt
@@ -1,0 +1,61 @@
+package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.RoomDTO
+
+/**
+ * Reine Logik fuer Lobby-Room-Aktionen.
+ *
+ * Berechnet aus einem Server-Ergebnis ([RoomDTO] oder null) die Liste
+ * der State-Effekte, die das [LobbyViewModel] anwenden soll. Trifft
+ * alle fachlichen Entscheidungen:
+ *  - Was zaehlt als Erfolg (RoomId nicht leer + Antwort vorhanden)
+ *  - Welche Fehlermeldung wird angezeigt
+ *  - Ob der Dialog geschlossen wird
+ *  - Ob navigiert wird
+ *
+ * Seiteneffekt-frei und damit ohne Coroutine- oder Compose-Runtime
+ * testbar.
+ */
+object LobbyRoomLogic {
+
+    /** Effekte fuer das Ergebnis eines createRoom-Aufrufs. */
+    fun effectsForCreateResult(room: RoomDTO?): List<LobbyEffect> =
+        if (room != null && room.roomId.isNotBlank()) {
+            listOf(
+                LobbyEffect.SetRoomId(room.roomId),
+                LobbyEffect.NavigateToWaiting,
+            )
+        } else {
+            listOf(LobbyEffect.ShowError("Raum konnte nicht erstellt werden"))
+        }
+
+    /** Effekte fuer das Ergebnis eines findByCode-Aufrufs. */
+    fun effectsForJoinByCodeResult(room: RoomDTO?, code: String): List<LobbyEffect> =
+        if (room != null && room.roomId.isNotBlank()) {
+            listOf(
+                LobbyEffect.SetRoomId(room.roomId),
+                LobbyEffect.CloseJoinDialog,
+                LobbyEffect.NavigateToWaiting,
+            )
+        } else {
+            listOf(LobbyEffect.ShowError("Kein Raum mit Code '$code' gefunden"))
+        }
+
+    /** Effekte fuer das Ergebnis eines joinRandom-Aufrufs. */
+    fun effectsForJoinRandomResult(room: RoomDTO?): List<LobbyEffect> =
+        if (room != null && room.roomId.isNotBlank()) {
+            listOf(
+                LobbyEffect.SetRoomId(room.roomId),
+                LobbyEffect.NavigateToWaiting,
+            )
+        } else {
+            listOf(LobbyEffect.ShowError("Kein freier Raum gefunden"))
+        }
+
+    /**
+     * Prueft, ob ein Join-Versuch ueberhaupt gestartet werden darf.
+     * Wird vom ViewModel als Gate vor dem API-Call genutzt -- damit
+     * landet auch diese Validierungs-Entscheidung nicht im VM.
+     */
+    fun canAttemptJoin(state: LobbyState): Boolean = state.canJoin
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt
@@ -137,9 +137,7 @@ fun LobbyScreen(
             onCodeChange = viewModel::onCodeChange,
             onDismiss = viewModel::closeJoinDialog,
             onJoin = {
-                if (viewModel.tryJoinByCode()) {
-                    navController.navigate(waitingScreen.route)
-                }
+                navController.navigate(waitingScreen.route)
             }
         )
     }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyState.kt
@@ -13,9 +13,11 @@ package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
  */
 data class LobbyState(
     val showJoinDialog: Boolean = false,
-    val code: String = ""
+    val code: String = "",
+    val isLoading: Boolean = false,
+    val error: String? = null
 ) {
-    /** True wenn der aktuelle Code gueltig ist (4-8 Zeichen). */
+    /** True wenn der aktuelle Code gueltig ist (4-8 Zeichen) und nicht geladen wird. */
     val canJoin: Boolean
-        get() = JoinByCodeLogic.isValid(code)
+        get() = !isLoading && JoinByCodeLogic.isValid(code)
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
@@ -1,41 +1,52 @@
 package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import at.aau.serg.websocketbrokerdemo.network.GameSession
+import at.aau.serg.websocketbrokerdemo.network.RoomApiClient
+import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel der Modus-Lobby.
  *
- * Haelt den UI-State (Dialog-Sichtbarkeit, Code-Eingabe) und stellt
- * Handler fuer die drei Lobby-Aktionen bereit. Die eigentliche
- * Navigation laeuft nicht durch das ViewModel -- die Aufrufer-Seite
- * (LobbyScreen) navigiert mit dem NavController, sobald das ViewModel
- * signalisiert "joinen ok". So bleibt das ViewModel frei von Compose-
- * Navigation-Abhaengigkeiten und ist sauber unit-testbar.
+ * Haelt den UI-State (Dialog-Sichtbarkeit, Code-Eingabe, Error, Loading)
+ * und delegiert die Entscheidungs-Logik an [LobbyRoomLogic].
  *
- * Da der Dialog-State (Code-Eingabe) im ViewModel lebt statt im
- * Composable, wird er beim Wiederoeffnen des Dialogs aktiv geleert --
- * siehe [openJoinDialog] und [closeJoinDialog].
+ * Die eigentliche Navigation wird ueber den [effects]-Flow an den
+ * [LobbyScreen] signalisiert, damit das ViewModel frei von Compose-
+ * Navigation-Abhaengigkeiten bleibt.
  */
-class LobbyViewModel : ViewModel() {
+class LobbyViewModel(
+    private val apiClient: RoomApiClient = RoomApiClient(),
+    private val session: GameSession? = null,
+) : ViewModel() {
 
     private val _state = MutableStateFlow(LobbyState())
 
     /** Public State, vom Composable ueber collectAsStateWithLifecycle gelesen. */
     val state: StateFlow<LobbyState> = _state.asStateFlow()
 
+    private val _effects = MutableSharedFlow<LobbyEffect>()
+    /** Einmalige Effekte (Navigation, Fehler-Snackbars etc.) */
+    val effects: SharedFlow<LobbyEffect> = _effects.asSharedFlow()
+
     // ---- Dialog-Lifecycle ----------------------------------------------
 
     /** Oeffnet den "Beitreten via Code"-Dialog mit leerem Eingabefeld. */
     fun openJoinDialog() {
-        _state.value = LobbyState(showJoinDialog = true, code = "")
+        _state.value = LobbyState(showJoinDialog = true, code = "", error = null)
     }
 
     /** Schliesst den Dialog ohne weitere Aktion (Cancel). */
     fun closeJoinDialog() {
-        _state.value = _state.value.copy(showJoinDialog = false)
+        _state.value = _state.value.copy(showJoinDialog = false, error = null)
     }
 
     // ---- Code-Eingabe --------------------------------------------------
@@ -45,19 +56,47 @@ class LobbyViewModel : ViewModel() {
      * an, damit der State stets in einem gueltigen Format bleibt.
      */
     fun onCodeChange(rawInput: String) {
-        _state.value = _state.value.copy(code = JoinByCodeLogic.normalize(rawInput))
+        _state.value = _state.value.copy(code = JoinByCodeLogic.normalize(rawInput), error = null)
     }
 
     // ---- Beitritts-Aktionen --------------------------------------------
 
-    /**
-     * Versucht beizutreten. Liefert true, wenn der Code gueltig ist und
-     * der Aufrufer (Screen) navigieren darf. Im Erfolgsfall wird der
-     * Dialog automatisch geschlossen.
-     */
-    fun tryJoinByCode(): Boolean {
-        if (!_state.value.canJoin) return false
-        _state.value = _state.value.copy(showJoinDialog = false)
-        return true
+    /** Erstellt einen privaten Raum fuer den gewaehlten Modus. */
+    fun createPrivateGame(mode: GameMode) {
+        if (_state.value.isLoading) return
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            val room = apiClient.createRoom(mapUiToDataMode(mode))
+            applyEffects(LobbyRoomLogic.effectsForCreateResult(room))
+        }
     }
+
+    /** Versucht via Code einem Raum beizutreten. */
+    fun tryJoinByCode() {
+        if (!LobbyRoomLogic.canAttemptJoin(_state.value)) return
+        val code = _state.value.code
+
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            val room = apiClient.findByCode(code)
+            applyEffects(LobbyRoomLogic.effectsForJoinByCodeResult(room, code))
+        }
+    }
+
+    // ---- Internes -------------------------------------------------------
+
+    private suspend fun applyEffects(effects: List<LobbyEffect>) {
+        _state.value = _state.value.copy(isLoading = false)
+        effects.forEach { effect ->
+            when (effect) {
+                is LobbyEffect.SetRoomId -> session?.activeRoomId?.value = effect.roomId
+                is LobbyEffect.CloseJoinDialog -> _state.value = _state.value.copy(showJoinDialog = false)
+                is LobbyEffect.ShowError -> _state.value = _state.value.copy(error = effect.message)
+                is LobbyEffect.NavigateToWaiting -> _effects.emit(effect)
+            }
+        }
+    }
+
+    private fun mapUiToDataMode(mode: GameMode): at.aau.serg.websocketbrokerdemo.data.serverside.GameMode =
+        at.aau.serg.websocketbrokerdemo.data.serverside.GameMode.valueOf(mode.name)
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogicTest.kt
@@ -1,0 +1,94 @@
+package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameMode
+import at.aau.serg.websocketbrokerdemo.data.serverside.RoomDTO
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LobbyRoomLogicTest {
+
+    @Test
+    fun `effectsForCreateResult returns success effects when room is valid`() {
+        val room = RoomDTO(joinCode = "ROOM123", mode = GameMode.DUAL_VALLEY, players = emptyList())
+        val effects = LobbyRoomLogic.effectsForCreateResult(room)
+
+        assertEquals(2, effects.size)
+        assertTrue(effects.any { it is LobbyEffect.SetRoomId && it.roomId == "ROOM123" })
+        assertTrue(effects.any { it is LobbyEffect.NavigateToWaiting })
+    }
+
+    @Test
+    fun `effectsForCreateResult returns error when room is null`() {
+        val effects = LobbyRoomLogic.effectsForCreateResult(null)
+
+        assertEquals(1, effects.size)
+        val effect = effects[0] as LobbyEffect.ShowError
+        assertTrue(effect.message.contains("nicht erstellt"))
+    }
+
+    @Test
+    fun `effectsForCreateResult returns error when roomId is blank`() {
+        val room = RoomDTO(joinCode = "  ", mode = GameMode.DUAL_VALLEY, players = emptyList())
+        val effects = LobbyRoomLogic.effectsForCreateResult(room)
+
+        assertEquals(1, effects.size)
+        val effect = effects[0] as LobbyEffect.ShowError
+        assertTrue(effect.message.contains("nicht erstellt"))
+    }
+
+    @Test
+    fun `effectsForJoinByCodeResult returns success effects when room is valid`() {
+        val room = RoomDTO(joinCode = "ROOM456", mode = GameMode.DUAL_VALLEY, players = emptyList())
+        val effects = LobbyRoomLogic.effectsForJoinByCodeResult(room, "1234")
+
+        assertEquals(3, effects.size)
+        assertTrue(effects.any { it is LobbyEffect.SetRoomId && it.roomId == "ROOM456" })
+        assertTrue(effects.any { it is LobbyEffect.CloseJoinDialog })
+        assertTrue(effects.any { it is LobbyEffect.NavigateToWaiting })
+    }
+
+    @Test
+    fun `effectsForJoinByCodeResult returns error including code when join fails`() {
+        // Case 1: room is null
+        val effectsNull = LobbyRoomLogic.effectsForJoinByCodeResult(null, "ABCD")
+        assertEquals(1, effectsNull.size)
+        assertTrue((effectsNull[0] as LobbyEffect.ShowError).message.contains("ABCD"))
+
+        // Case 2: room is not null but roomId is blank
+        val roomBlank = RoomDTO(joinCode = "", mode = GameMode.DUAL_VALLEY, players = emptyList())
+        val effectsBlank = LobbyRoomLogic.effectsForJoinByCodeResult(roomBlank, "EFGH")
+        assertEquals(1, effectsBlank.size)
+        assertTrue((effectsBlank[0] as LobbyEffect.ShowError).message.contains("EFGH"))
+    }
+
+    @Test
+    fun `effectsForJoinRandomResult returns success effects when room is valid`() {
+        val room = RoomDTO(joinCode = "RAND123", mode = GameMode.DUAL_VALLEY, players = emptyList())
+        val effects = LobbyRoomLogic.effectsForJoinRandomResult(room)
+
+        assertEquals(2, effects.size)
+        assertTrue(effects.any { it is LobbyEffect.SetRoomId && it.roomId == "RAND123" })
+        assertTrue(effects.any { it is LobbyEffect.NavigateToWaiting })
+    }
+
+    @Test
+    fun `effectsForJoinRandomResult returns error when room is null`() {
+        val effects = LobbyRoomLogic.effectsForJoinRandomResult(null)
+
+        assertEquals(1, effects.size)
+        val effect = effects[0] as LobbyEffect.ShowError
+        assertTrue(effect.message.contains("Kein freier Raum"))
+    }
+
+    @Test
+    fun `canAttemptJoin returns state canJoin`() {
+        // JoinByCodeLogic.isValid requires 4 to 8 chars
+        val stateJoinable = LobbyState(code = "1234")
+        val stateNotJoinable = LobbyState(code = "12")
+
+        assertTrue(LobbyRoomLogic.canAttemptJoin(stateJoinable))
+        assertFalse(LobbyRoomLogic.canAttemptJoin(stateNotJoinable))
+    }
+}

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModelTest.kt
@@ -1,7 +1,19 @@
 package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
 
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameMode
+import at.aau.serg.websocketbrokerdemo.data.serverside.RoomDTO
+import at.aau.serg.websocketbrokerdemo.network.RoomApiClient
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -9,17 +21,26 @@ import org.junit.jupiter.api.Test
 /**
  * Tests fuer LobbyViewModel.
  *
- * Reine State-Maschine ohne Coroutines, daher kein Coroutine-Setup
- * noetig. Geprueft werden Dialog-Lifecycle, Code-Eingabe und der
- * Join-Versuch mit gueltigem/ungueltigem Code.
+ * Verwendet MockK fuer den RoomApiClient und den UnconfinedTestDispatcher
+ * fuer Coroutines, damit Effekte sofort im State sichtbar werden.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class LobbyViewModelTest {
 
+    private lateinit var apiClient: RoomApiClient
     private lateinit var vm: LobbyViewModel
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @BeforeEach
     fun setUp() {
-        vm = LobbyViewModel()
+        Dispatchers.setMain(testDispatcher)
+        apiClient = mockk()
+        vm = LobbyViewModel(apiClient)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     // ---- Initialer State -----------------------------------------------
@@ -29,7 +50,8 @@ class LobbyViewModelTest {
         val state = vm.state.value
         assertFalse(state.showJoinDialog)
         assertEquals("", state.code)
-        assertFalse(state.canJoin)
+        assertNull(state.error)
+        assertFalse(state.isLoading)
     }
 
     // ---- Dialog-Lifecycle ----------------------------------------------
@@ -41,76 +63,59 @@ class LobbyViewModelTest {
     }
 
     @Test
-    fun `openJoinDialog resets the code field`() {
-        // Wenn der User schon mal getippt hat und den Dialog wieder
-        // oeffnet, darf der alte Inhalt nicht stehenbleiben.
+    fun `openJoinDialog resets the code field and error`() {
         vm.onCodeChange("ABCD")
         vm.closeJoinDialog()
         vm.openJoinDialog()
         assertEquals("", vm.state.value.code)
+        assertNull(vm.state.value.error)
+    }
+
+    // ---- Beitritts-Aktionen --------------------------------------------
+
+    @Test
+    fun `createPrivateGame calls API and sets state`() {
+        val room = RoomDTO(joinCode = "ROOM1", mode = GameMode.DUAL_VALLEY, players = emptyList())
+        coEvery { apiClient.createRoom(any()) } returns room
+
+        vm.createPrivateGame(at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode.DUAL_VALLEY)
+
+        assertFalse(vm.state.value.isLoading)
+        assertNull(vm.state.value.error)
     }
 
     @Test
-    fun `closeJoinDialog sets showJoinDialog to false`() {
+    fun `createPrivateGame sets error when API fails`() {
+        coEvery { apiClient.createRoom(any()) } returns null
+
+        vm.createPrivateGame(at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode.DUAL_VALLEY)
+
+        assertFalse(vm.state.value.isLoading)
+        assertEquals("Raum konnte nicht erstellt werden", vm.state.value.error)
+    }
+
+    @Test
+    fun `tryJoinByCode calls API and closes dialog on success`() {
         vm.openJoinDialog()
-        vm.closeJoinDialog()
+        vm.onCodeChange("CODE1")
+        val room = RoomDTO(joinCode = "CODE1", mode = GameMode.DUAL_VALLEY, players = emptyList())
+        coEvery { apiClient.findByCode("CODE1") } returns room
+
+        vm.tryJoinByCode()
+
         assertFalse(vm.state.value.showJoinDialog)
-    }
-
-    // ---- Code-Eingabe --------------------------------------------------
-
-    @Test
-    fun `onCodeChange normalizes the input`() {
-        vm.onCodeChange("ab cd 12!")
-        assertEquals("ABCD12", vm.state.value.code)
+        assertNull(vm.state.value.error)
     }
 
     @Test
-    fun `onCodeChange caps at 8 characters`() {
-        vm.onCodeChange("ABCDEFGHIJKL")
-        assertEquals(8, vm.state.value.code.length)
-        assertEquals("ABCDEFGH", vm.state.value.code)
-    }
-
-    @Test
-    fun `onCodeChange to empty string clears the code`() {
-        vm.onCodeChange("ABCD")
-        vm.onCodeChange("")
-        assertEquals("", vm.state.value.code)
-    }
-
-    // ---- tryJoinByCode -------------------------------------------------
-
-    @Test
-    fun `tryJoinByCode returns false for invalid code`() {
+    fun `tryJoinByCode sets error on failure`() {
         vm.openJoinDialog()
-        vm.onCodeChange("AB")    // zu kurz
-        val result = vm.tryJoinByCode()
-        assertFalse(result)
-        // Dialog bleibt offen, der User soll seinen Code korrigieren koennen
+        vm.onCodeChange("CODE1")
+        coEvery { apiClient.findByCode("CODE1") } returns null
+
+        vm.tryJoinByCode()
+
         assertTrue(vm.state.value.showJoinDialog)
-    }
-
-    @Test
-    fun `tryJoinByCode returns true for valid code and closes dialog`() {
-        vm.openJoinDialog()
-        vm.onCodeChange("ABCD")
-        val result = vm.tryJoinByCode()
-        assertTrue(result)
-        assertFalse(vm.state.value.showJoinDialog)
-    }
-
-    @Test
-    fun `tryJoinByCode returns false when code is empty`() {
-        vm.openJoinDialog()
-        val result = vm.tryJoinByCode()
-        assertFalse(result)
-    }
-
-    @Test
-    fun `tryJoinByCode succeeds at 8 character boundary`() {
-        vm.openJoinDialog()
-        vm.onCodeChange("ABCDEFGH")
-        assertTrue(vm.tryJoinByCode())
+        assertTrue(vm.state.value.error!!.contains("CODE1"))
     }
 }


### PR DESCRIPTION
Implemented:

1. `ui/lobby_modes/LobbyEffect.kt` — sealed interface mit 4 Effect-Typen
2. `ui/lobby_modes/LobbyRoomLogic.kt` — pure object mit `effectsFor...`-
   Funktionen und `canAttemptJoin`

as requested in [issue](https://github.com/HexaBrawl/app/issues/138).

Additionally, logic and API were implemented in LobbyViewModel

