### PR TITLE
Fix waiting lobby flow and color sync

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
@@ -106,7 +106,14 @@ class LobbyViewModel(
         _state.value = _state.value.copy(isLoading = false)
         effects.forEach { effect ->
             when (effect) {
-                is LobbyEffect.SetRoomId -> session.activeRoomId.value = effect.roomId
+                is LobbyEffect.SetRoomId -> {
+                    session.activeRoomId.value = effect.roomId
+                    // Neuer Raum: alle stale States aus vorherigen Spielen
+                    // wegwerfen, damit die WaitingLobby nicht alte Spieler
+                    // oder Fehler anzeigt.
+                    session.gameState.value = null
+                    session.lastError.value = null
+                }
                 is LobbyEffect.SetJoinCode -> session.activeJoinCode.value = effect.joinCode
                 is LobbyEffect.CloseJoinDialog -> _state.value = _state.value.copy(showJoinDialog = false)
                 is LobbyEffect.ShowError -> {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import at.aau.serg.websocketbrokerdemo.data.serverside.ErrorCode
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
+import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
 import at.aau.serg.websocketbrokerdemo.network.GameSession
 import at.aau.serg.websocketbrokerdemo.ui.navigation.Screen
 
@@ -31,9 +32,15 @@ fun LobbyNetworkSync(
     navController: NavController
 ) {
     val viewModelState by viewModel.state.collectAsStateWithLifecycle()
-    val localName = viewModel.localName
-    val localColor = viewModel.localColor
-    val localReady = viewModel.localReady
+    // Lokale Werte direkt aus dem observed State ableiten -- damit Compose
+    // die Recomposition garantiert triggert, wenn der User Name, Farbe
+    // oder Ready-Status aendert. Direkte Aufrufe von viewModel.localXyz
+    // wurden zwar gelesen, aber nicht zuverlaessig fuer LaunchedEffect-Keys
+    // erfasst.
+    val localSlot = viewModelState.slots.firstOrNull { it.isLocal }
+    val localName = localSlot?.name.orEmpty()
+    val localColor = localSlot?.color ?: PlayerColor.RED
+    val localReady = localSlot?.ready ?: false
 
     DisposableEffect(session.activeRoomId.value) {
         val job = session.endpoint.subscribeToGameState(session.activeRoomId.value) { state ->

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
@@ -76,6 +76,16 @@ fun LobbyNetworkSync(
     LaunchedEffect(gameState) {
         val state = gameState ?: return@LaunchedEffect
 
+        // Lokalen Spieler im Server-State erkennen -> Name + Farbe locken.
+        // Wir verlassen uns nicht auf den joinGame-Send, sondern auf den
+        // tatsaechlichen Broadcast: wenn der Server den Spieler ablehnt
+        // (z.B. COLOR_ALREADY_TAKEN), taucht er nicht in der Liste auf
+        // und der Lock bleibt offen, sodass der User die Farbe wechseln
+        // kann.
+        if (state.players.any { it.name == localName }) {
+            viewModel.markJoinedServer()
+        }
+
         // Komplette Player-Objekte (mit Server-Farbe) weitergeben, damit
         // der Color-Picker im Wartelobby-UI konsistent zur Realitaet ist.
         val remotePlayers = state.players.filter { it.name != localName }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
@@ -69,11 +69,11 @@ fun LobbyNetworkSync(
     LaunchedEffect(gameState) {
         val state = gameState ?: return@LaunchedEffect
 
-        val remotePlayerNames = state.players
-            .filter { it.name != localName }
-            .map { it.name }
+        // Komplette Player-Objekte (mit Server-Farbe) weitergeben, damit
+        // der Color-Picker im Wartelobby-UI konsistent zur Realitaet ist.
+        val remotePlayers = state.players.filter { it.name != localName }
 
-        viewModel.applyRemoteState(remotePlayerNames)
+        viewModel.applyRemoteState(remotePlayers)
     }
 
     // Zum GameScreen navigieren -- aber erst NACHDEM der Countdown

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import at.aau.serg.websocketbrokerdemo.data.serverside.ErrorCode
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
 import at.aau.serg.websocketbrokerdemo.network.GameSession
 import at.aau.serg.websocketbrokerdemo.ui.navigation.Screen
@@ -86,5 +87,31 @@ fun LobbyNetworkSync(
                 popUpTo(Screen.Home.route) { inclusive = false }
             }
         }
+    }
+
+    // Server-Fehler beobachten und sinnvoll behandeln.
+    //
+    // Speziell COLOR_ALREADY_TAKEN: der lokale Spieler hat eine Farbe
+    // gewaehlt, die schon belegt war. Wir setzen den ready-Status zurueck
+    // (damit der User die Farbe wieder wechseln kann) und zeigen eine
+    // Snackbar mit einem klaren Hinweis.
+    //
+    // Andere Fehler werden 1:1 als Snackbar gezeigt; die App bleibt
+    // ansonsten im aktuellen State.
+    val lastError by session.lastError
+    LaunchedEffect(lastError) {
+        val error = lastError ?: return@LaunchedEffect
+        when (error.errorCode) {
+            ErrorCode.COLOR_ALREADY_TAKEN -> {
+                viewModel.clearLocalReady()
+                viewModel.showError(error.message)
+            }
+            else -> {
+                viewModel.showError(error.message)
+            }
+        }
+        // Error in der Session wieder loeschen, sonst triggert derselbe
+        // Effect bei jeder Recomposition erneut.
+        session.lastError.value = null
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
 import at.aau.serg.websocketbrokerdemo.network.GameSession
@@ -13,11 +14,14 @@ import at.aau.serg.websocketbrokerdemo.ui.navigation.Screen
  * Verbindet das Wartelobby-ViewModel mit dem GameSession-Netzwerk.
  *
  * Verantwortungen:
- *  - Beim Aufruf: lokalen Spieler + gewaehlte Farbe beim Server anmelden
  *  - GameState-Subscription verwalten (DisposableEffect)
  *  - Server-Updates an [WaitingLobbyViewModel.applyRemoteState]
  *    weiterreichen
- *  - Bei status = IN_PROGRESS zum GameScreen navigieren
+ *  - Lokalen Spieler erst dann beim Server anmelden, wenn der User
+ *    "Ready" geklickt hat -- vorher hat er Zeit, Name und Farbe zu
+ *    waehlen
+ *  - Zum GameScreen navigieren, sobald der Countdown durchgelaufen ist
+ *    UND der Server den Spielstatus auf IN_PROGRESS gesetzt hat
  */
 @Composable
 fun LobbyNetworkSync(
@@ -25,7 +29,10 @@ fun LobbyNetworkSync(
     viewModel: WaitingLobbyViewModel,
     navController: NavController
 ) {
+    val viewModelState by viewModel.state.collectAsStateWithLifecycle()
     val localName = viewModel.localName
+    val localColor = viewModel.localColor
+    val localReady = viewModel.localReady
 
     DisposableEffect(session.activeRoomId.value) {
         val job = session.endpoint.subscribeToGameState(session.activeRoomId.value) { state ->
@@ -34,26 +41,30 @@ fun LobbyNetworkSync(
         onDispose { job.cancel() }
     }
 
-    // Anmelden sobald der lokale Name feststeht.
+    // Anmelden erst wenn der User "Ready" geklickt hat.
     //
-    // Die Farbe wird BEWUSST nicht mitgeschickt (color = null). Der Server
-    // vergibt selbst eine freie Farbe und broadcasted sie ueber den
-    // GameState an alle Spieler im Raum. Damit gibt es keinen Konflikt
-    // mehr, wenn beide Clients lokal mit dem RED-Default ihres Slots
-    // initialisiert werden -- der zweite Spieler wuerde sonst vom Server
-    // mit COLOR_ALREADY_TAKEN abgelehnt und taucht in keinem Raum auf.
-    LaunchedEffect(localName) {
-        if (localName.isNotBlank()) {
+    // Der User hat in der WaitingLobby zuvor seinen Namen und seine Farbe
+    // gewaehlt. Der Klick auf "Ready" setzt im lokalen Slot ready=true
+    // und triggert diesen Effect. Die gewaehlte Farbe wird mitgegeben --
+    // bei Konflikt (zwei Spieler waehlen die gleiche Farbe) lehnt der
+    // Server mit COLOR_ALREADY_TAKEN ab; das Error-Handling dafuer kommt
+    // als Follow-up.
+    LaunchedEffect(localReady, localName, localColor) {
+        if (localReady && localName.isNotBlank() && session.activeRoomId.value.isNotBlank()) {
             session.localPlayerName.value = localName
             session.endpoint.joinGame(
                 roomId = session.activeRoomId.value,
                 playerName = localName,
-                color = null
+                color = localColor
             )
         }
     }
 
     val gameState by session.gameState
+
+    // Server-Updates an das ViewModel weiterreichen (Slots, Spielerliste).
+    // Navigation passiert bewusst NICHT hier, sondern erst nachdem der
+    // Countdown im ViewModel abgelaufen ist (siehe LaunchedEffect unten).
     LaunchedEffect(gameState) {
         val state = gameState ?: return@LaunchedEffect
 
@@ -62,8 +73,15 @@ fun LobbyNetworkSync(
             .map { it.name }
 
         viewModel.applyRemoteState(remotePlayerNames)
+    }
 
-        if (state.status == GameStatus.IN_PROGRESS) {
+    // Zum GameScreen navigieren -- aber erst NACHDEM der Countdown
+    // wirklich durchgelaufen ist. So sieht der User die 3-2-1-Anzeige,
+    // auch wenn der Server (Auto-Start sobald maxPlayers erreicht) den
+    // Status schon vorher auf IN_PROGRESS gesetzt hat.
+    LaunchedEffect(viewModelState.countdownComplete, gameState?.status) {
+        val status = gameState?.status ?: return@LaunchedEffect
+        if (viewModelState.countdownComplete && status == GameStatus.IN_PROGRESS) {
             navController.navigate(Screen.Game.route) {
                 popUpTo(Screen.Home.route) { inclusive = false }
             }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyScreen.kt
@@ -213,6 +213,7 @@ fun WaitingLobbyScreen(
                         slot = slot,
                         takenColors = takenColors,
                         countdownActive = state.isCountdownActive,
+                        joinedServer = state.joinedServer,
                         onNameChange = { viewModel.onNameChange(slot.id, it) },
                         onColorChange = { viewModel.onColorChange(slot.id, it) },
                         onReadyToggle = { viewModel.onReadyToggle(slot.id) }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyScreen.kt
@@ -16,9 +16,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -87,6 +91,16 @@ fun WaitingLobbyScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val clipboardManager = LocalClipboardManager.current
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Vom ViewModel gemeldete Fehler als Snackbar anzeigen und
+    // anschliessend aus dem State entfernen, damit sie nicht erneut
+    // auftauchen.
+    LaunchedEffect(state.errorMessage) {
+        val message = state.errorMessage ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+        viewModel.clearError()
+    }
 
     LobbyNetworkSync(
         session = session,
@@ -213,5 +227,12 @@ fun WaitingLobbyScreen(
         ) {
             CountdownOverlay(seconds = state.countdown)
         }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp)
+        )
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyScreen.kt
@@ -212,6 +212,7 @@ fun WaitingLobbyScreen(
                     slot.isLocal -> LocalPlayerSlotCard(
                         slot = slot,
                         takenColors = takenColors,
+                        countdownActive = state.isCountdownActive,
                         onNameChange = { viewModel.onNameChange(slot.id, it) },
                         onColorChange = { viewModel.onColorChange(slot.id, it) },
                         onReadyToggle = { viewModel.onReadyToggle(slot.id) }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
@@ -15,14 +15,21 @@ import at.aau.serg.websocketbrokerdemo.ui.waiting.model.PlayerSlot
  *  - joinCode   Menschenlesbarer 6-Zeichen-Code. Wird in der Wartelobby
  *               angezeigt und ist der Wert, den der User per Klick
  *               kopieren bzw. seinen Mitspielern weitergeben kann.
- *  - slots      Aktuelle Spieler-Slots (lokal + remote + leer)
- *  - countdown  Sekunden bis zum Spielstart, -1 wenn nicht laeuft
+ *  - slots             Aktuelle Spieler-Slots (lokal + remote + leer)
+ *  - countdown         Sekunden bis zum Spielstart, -1 wenn nicht laeuft
+ *  - countdownComplete True, sobald der Countdown auf 0 runtergezaehlt
+ *                      hat. Dient als Signal fuer die Navigation zum
+ *                      GameScreen -- erst wenn der Countdown wirklich
+ *                      durchgelaufen ist, wechselt die App auf das
+ *                      Spielfeld. Wird beim Start eines neuen Countdowns
+ *                      wieder auf false gesetzt.
  */
 data class WaitingLobbyState(
     val roomId: String = "",
     val joinCode: String = "",
     val slots: List<PlayerSlot> = emptyList(),
-    val countdown: Int = -1
+    val countdown: Int = -1,
+    val countdownComplete: Boolean = false
 ) {
     /** True wenn der Countdown gerade laeuft. */
     val isCountdownActive: Boolean

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
@@ -27,6 +27,12 @@ import at.aau.serg.websocketbrokerdemo.ui.waiting.model.PlayerSlot
  *                      ist bereits vergeben"). Wird vom WaitingLobby-
  *                      Screen als Snackbar angezeigt und nach dem
  *                      Verschwinden ueber clearError() zurueckgesetzt.
+ *  - joinedServer      True, sobald der Server den eigenen Spieler im
+ *                      GameState-Broadcast bestaetigt hat. Sperrt
+ *                      anschliessend Name- und Farbwahl, damit die
+ *                      lokale Anzeige nicht von der Server-Wahrheit
+ *                      abweicht. Der Ready-Toggle bleibt dagegen frei
+ *                      (User kann den Countdown jederzeit pausieren).
  */
 data class WaitingLobbyState(
     val roomId: String = "",
@@ -34,7 +40,8 @@ data class WaitingLobbyState(
     val slots: List<PlayerSlot> = emptyList(),
     val countdown: Int = -1,
     val countdownComplete: Boolean = false,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val joinedServer: Boolean = false
 ) {
     /** True wenn der Countdown gerade laeuft. */
     val isCountdownActive: Boolean

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyState.kt
@@ -23,13 +23,18 @@ import at.aau.serg.websocketbrokerdemo.ui.waiting.model.PlayerSlot
  *                      durchgelaufen ist, wechselt die App auf das
  *                      Spielfeld. Wird beim Start eines neuen Countdowns
  *                      wieder auf false gesetzt.
+ *  - errorMessage      Vom Server gemeldeter Fehler (z.B. "Diese Farbe
+ *                      ist bereits vergeben"). Wird vom WaitingLobby-
+ *                      Screen als Snackbar angezeigt und nach dem
+ *                      Verschwinden ueber clearError() zurueckgesetzt.
  */
 data class WaitingLobbyState(
     val roomId: String = "",
     val joinCode: String = "",
     val slots: List<PlayerSlot> = emptyList(),
     val countdown: Int = -1,
-    val countdownComplete: Boolean = false
+    val countdownComplete: Boolean = false,
+    val errorMessage: String? = null
 ) {
     /** True wenn der Countdown gerade laeuft. */
     val isCountdownActive: Boolean

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -2,6 +2,7 @@ package at.aau.serg.websocketbrokerdemo.ui.waiting
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
 import at.aau.serg.websocketbrokerdemo.ui.waiting.model.PlayerSlot
@@ -73,28 +74,30 @@ class WaitingLobbyViewModel(
     /**
      * Wird vom NetworkSync aufgerufen, wenn der Server eine neue
      * Spielerliste schickt. Aktualisiert die Slots 1..n (nicht den
-     * lokalen Slot 0) und weist ihnen die noch freien Farben zu.
+     * lokalen Slot 0).
+     *
+     * Wichtig: die Farben der Remote-Spieler werden 1:1 aus dem Server-
+     * GameState uebernommen -- damit sieht der Color-Picker in jeder
+     * App konsistent welche Farben schon belegt sind, und der User kann
+     * keinen Konflikt mehr ausloesen, indem er eine Farbe waehlt, die
+     * ein anderer Spieler schon hat.
      */
-    fun applyRemoteState(remotePlayerNames: List<String>) {
+    fun applyRemoteState(remotePlayers: List<Player>) {
         val currentSlots = _state.value.slots
-        val localSlot = currentSlots.firstOrNull { it.isLocal } ?: return
-        val takenColors = mutableSetOf(localSlot.color)
 
         val newSlots = currentSlots.mapIndexed { index, slot ->
             if (slot.isLocal) {
                 slot
             } else {
                 val remoteIndex = index - 1
-                val remoteName = remotePlayerNames.getOrNull(remoteIndex)
-                if (remoteName == null) {
+                val remotePlayer = remotePlayers.getOrNull(remoteIndex)
+                if (remotePlayer == null) {
                     slot.copy(status = SlotStatus.Empty, name = "", ready = false)
                 } else {
-                    val color = PlayerColor.entries.first { it !in takenColors }
-                    takenColors += color
                     slot.copy(
                         status = SlotStatus.Player,
-                        name = remoteName,
-                        color = color,
+                        name = remotePlayer.name,
+                        color = remotePlayer.color,
                         ready = true,
                         isLocal = false
                     )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -105,6 +105,37 @@ class WaitingLobbyViewModel(
         updateSlots(newSlots)
     }
 
+    // ---- Fehler-Handling -----------------------------------------------
+
+    /**
+     * Setzt den lokalen Slot 0 explizit auf ready=false. Wird vom
+     * NetworkSync aufgerufen, wenn der Server den Beitritt mit
+     * COLOR_ALREADY_TAKEN abgelehnt hat -- damit ist der Slot wieder
+     * editierbar und der User kann eine andere Farbe waehlen.
+     */
+    fun clearLocalReady() {
+        val newSlots = _state.value.slots.map { slot ->
+            if (slot.isLocal) slot.copy(ready = false) else slot
+        }
+        updateSlots(newSlots)
+    }
+
+    /**
+     * Setzt eine Fehlermeldung, die der Screen als Snackbar anzeigen
+     * soll.
+     */
+    fun showError(message: String) {
+        _state.value = _state.value.copy(errorMessage = message)
+    }
+
+    /**
+     * Wird nach dem Schliessen der Snackbar aufgerufen, damit die
+     * gleiche Fehlermeldung nicht erneut auftaucht.
+     */
+    fun clearError() {
+        _state.value = _state.value.copy(errorMessage = null)
+    }
+
     // ---- Internes -------------------------------------------------------
 
     private fun updateSlots(newSlots: List<PlayerSlot>) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -85,7 +85,7 @@ class WaitingLobbyViewModel(
     fun applyRemoteState(remotePlayers: List<Player>) {
         val currentSlots = _state.value.slots
 
-        val newSlots = currentSlots.mapIndexed { index, slot ->
+        var newSlots = currentSlots.mapIndexed { index, slot ->
             if (slot.isLocal) {
                 slot
             } else {
@@ -101,6 +101,30 @@ class WaitingLobbyViewModel(
                         ready = true,
                         isLocal = false
                     )
+                }
+            }
+        }
+
+        // Auto-Reassign: wenn der lokale Slot eine Farbe hat, die ein
+        // Remote-Spieler bereits belegt, UND der User noch nicht "ready"
+        // geklickt hat, vergeben wir automatisch die naechste freie Farbe.
+        // Damit muss der User nicht jedes Mal manuell wechseln, wenn sein
+        // RED-Default mit dem RED-Default des Hosts kollidiert.
+        // Wenn der User schon bewusst ready geklickt hat, lassen wir seine
+        // Wahl unangetastet -- ein Color-Konflikt wird dann vom Server
+        // ueber COLOR_ALREADY_TAKEN abgefangen.
+        val localSlot = newSlots.firstOrNull { it.isLocal }
+        if (localSlot != null && !localSlot.ready) {
+            val remoteColors = newSlots
+                .filter { !it.isLocal && it.status != SlotStatus.Empty }
+                .map { it.color }
+                .toSet()
+            if (localSlot.color in remoteColors) {
+                val freeColor = PlayerColor.entries.firstOrNull { it !in remoteColors }
+                if (freeColor != null) {
+                    newSlots = newSlots.map { s ->
+                        if (s.isLocal) s.copy(color = freeColor) else s
+                    }
                 }
             }
         }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -102,53 +102,60 @@ class WaitingLobbyViewModel(
      * ein anderer Spieler schon hat.
      */
     fun applyRemoteState(remotePlayers: List<Player>) {
-        val currentSlots = _state.value.slots
+        val withRemoteSlots = mapRemoteSlots(_state.value.slots, remotePlayers)
+        val finalSlots = autoReassignLocalColorIfNeeded(withRemoteSlots)
+        updateSlots(finalSlots)
+    }
 
-        var newSlots = currentSlots.mapIndexed { index, slot ->
-            if (slot.isLocal) {
-                slot
-            } else {
-                val remoteIndex = index - 1
-                val remotePlayer = remotePlayers.getOrNull(remoteIndex)
-                if (remotePlayer == null) {
-                    slot.copy(status = SlotStatus.Empty, name = "", ready = false)
-                } else {
-                    slot.copy(
-                        status = SlotStatus.Player,
-                        name = remotePlayer.name,
-                        color = remotePlayer.color,
-                        ready = true,
-                        isLocal = false
-                    )
-                }
-            }
+    /**
+     * Setzt die Remote-Slots (alle nicht-lokalen Slots) auf den Server-
+     * Stand: Spieler-Daten falls vorhanden, Empty sonst. Der lokale
+     * Slot bleibt unangetastet.
+     */
+    private fun mapRemoteSlots(
+        currentSlots: List<PlayerSlot>,
+        remotePlayers: List<Player>
+    ): List<PlayerSlot> = currentSlots.mapIndexed { index, slot ->
+        if (slot.isLocal) slot
+        else applyRemoteToSlot(slot, remotePlayers.getOrNull(index - 1))
+    }
+
+    private fun applyRemoteToSlot(slot: PlayerSlot, remotePlayer: Player?): PlayerSlot =
+        if (remotePlayer == null) {
+            slot.copy(status = SlotStatus.Empty, name = "", ready = false)
+        } else {
+            slot.copy(
+                status = SlotStatus.Player,
+                name = remotePlayer.name,
+                color = remotePlayer.color,
+                ready = true,
+                isLocal = false
+            )
         }
 
-        // Auto-Reassign: wenn der lokale Slot eine Farbe hat, die ein
-        // Remote-Spieler bereits belegt, UND der User noch nicht "ready"
-        // geklickt hat, vergeben wir automatisch die naechste freie Farbe.
-        // Damit muss der User nicht jedes Mal manuell wechseln, wenn sein
-        // RED-Default mit dem RED-Default des Hosts kollidiert.
-        // Wenn der User schon bewusst ready geklickt hat, lassen wir seine
-        // Wahl unangetastet -- ein Color-Konflikt wird dann vom Server
-        // ueber COLOR_ALREADY_TAKEN abgefangen.
-        val localSlot = newSlots.firstOrNull { it.isLocal }
-        if (localSlot != null && !localSlot.ready) {
-            val remoteColors = newSlots
-                .filter { !it.isLocal && it.status != SlotStatus.Empty }
-                .map { it.color }
-                .toSet()
-            if (localSlot.color in remoteColors) {
-                val freeColor = PlayerColor.entries.firstOrNull { it !in remoteColors }
-                if (freeColor != null) {
-                    newSlots = newSlots.map { s ->
-                        if (s.isLocal) s.copy(color = freeColor) else s
-                    }
-                }
-            }
-        }
+    /**
+     * Auto-Reassign: wenn der lokale Slot eine Farbe hat, die ein
+     * Remote-Spieler bereits belegt, UND der User noch nicht "ready"
+     * geklickt hat, vergeben wir automatisch die naechste freie Farbe.
+     * Damit muss der User nicht jedes Mal manuell wechseln, wenn sein
+     * RED-Default mit dem RED-Default des Hosts kollidiert.
+     *
+     * Wenn der User schon bewusst ready geklickt hat, lassen wir seine
+     * Wahl unangetastet -- ein Color-Konflikt wird dann vom Server ueber
+     * COLOR_ALREADY_TAKEN abgefangen.
+     */
+    private fun autoReassignLocalColorIfNeeded(slots: List<PlayerSlot>): List<PlayerSlot> {
+        val localSlot = slots.firstOrNull { it.isLocal } ?: return slots
+        if (localSlot.ready) return slots
 
-        updateSlots(newSlots)
+        val remoteColors = slots
+            .filter { !it.isLocal && it.status != SlotStatus.Empty }
+            .map { it.color }
+            .toSet()
+        if (localSlot.color !in remoteColors) return slots
+
+        val freeColor = PlayerColor.entries.firstOrNull { it !in remoteColors } ?: return slots
+        return slots.map { if (it.isLocal) it.copy(color = freeColor) else it }
     }
 
     // ---- Fehler-Handling -----------------------------------------------

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -169,6 +169,18 @@ class WaitingLobbyViewModel(
         _state.value = _state.value.copy(errorMessage = null)
     }
 
+    /**
+     * Wird vom NetworkSync aufgerufen, sobald der Server den lokalen
+     * Spieler in einem GameState-Broadcast bestaetigt. Setzt das
+     * joinedServer-Flag, das im UI Name- und Farbwahl sperrt.
+     *
+     * Idempotent: ein zweiter Aufruf aendert nichts mehr.
+     */
+    fun markJoinedServer() {
+        if (_state.value.joinedServer) return
+        _state.value = _state.value.copy(joinedServer = true)
+    }
+
     // ---- Internes -------------------------------------------------------
 
     private fun updateSlots(newSlots: List<PlayerSlot>) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -50,6 +50,10 @@ class WaitingLobbyViewModel(
     val localColor: PlayerColor
         get() = _state.value.slots.firstOrNull { it.isLocal }?.color ?: PlayerColor.RED
 
+    /** Ob der lokale Spieler bereits "Ready" geklickt hat (fuer NetworkSync). */
+    val localReady: Boolean
+        get() = _state.value.slots.firstOrNull { it.isLocal }?.ready ?: false
+
     // ---- User-Aktionen --------------------------------------------------
 
     fun onNameChange(slotId: Int, newName: String) {
@@ -120,19 +124,22 @@ class WaitingLobbyViewModel(
     private fun startCountdown() {
         countdownJob = viewModelScope.launch {
             var remaining = COUNTDOWN_SECONDS
-            _state.value = _state.value.copy(countdown = remaining)
+            _state.value = _state.value.copy(countdown = remaining, countdownComplete = false)
             while (remaining > 0) {
                 delay(COUNTDOWN_TICK_MS)
                 remaining -= 1
                 _state.value = _state.value.copy(countdown = remaining)
             }
+            // Countdown durchgelaufen -> Signal an LobbyNetworkSync, dass jetzt
+            // zum GameScreen navigiert werden darf.
+            _state.value = _state.value.copy(countdownComplete = true)
         }
     }
 
     private fun cancelCountdown() {
         countdownJob?.cancel()
         countdownJob = null
-        _state.value = _state.value.copy(countdown = -1)
+        _state.value = _state.value.copy(countdown = -1, countdownComplete = false)
     }
 
     override fun onCleared() {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -66,6 +66,12 @@ class WaitingLobbyViewModel(
     }
 
     fun onReadyToggle(slotId: Int) {
+        // Waehrend der 3-2-1-Countdown laeuft, ignorieren wir Ready-Toggles.
+        // Sonst kann der User sein "Bereit" kurz vor dem Spielstart wieder
+        // zuruecknehmen, der Server hat aber schon Auto-Start ausgeloest --
+        // dann wuerde die App ihn trotzdem ins Spiel navigieren und der
+        // User waere irritiert.
+        if (_state.value.isCountdownActive) return
         updateSlots(WaitingLobbyLogic.applyReadyToggle(_state.value.slots, slotId))
     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -72,6 +72,19 @@ class WaitingLobbyViewModel(
         // dann wuerde die App ihn trotzdem ins Spiel navigieren und der
         // User waere irritiert.
         if (_state.value.isCountdownActive) return
+
+        // Sobald der lokale Slot ready ist, ignorieren wir weitere
+        // Toggle-Klicks. Der Server kennt keinen "leave"-Endpoint, der
+        // Auto-Start kann den lokalen Unready ueberholen, und der User
+        // landet in einem Game ohne den anderen Spieler oder umgekehrt.
+        // Wenn der User doch raus will, gibt es den BACK-Button.
+        //
+        // Die Recovery bei COLOR_ALREADY_TAKEN funktioniert weiter, weil
+        // clearLocalReady() den slot.ready direkt manipuliert (bypass
+        // dieses Checks).
+        val slot = _state.value.slots.firstOrNull { it.id == slotId }
+        if (slot?.ready == true) return
+
         updateSlots(WaitingLobbyLogic.applyReadyToggle(_state.value.slots, slotId))
     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/components/LocalPlayerSlotCard.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/components/LocalPlayerSlotCard.kt
@@ -53,11 +53,17 @@ import com.example.myapplication.R
 fun LocalPlayerSlotCard(
     slot: PlayerSlot,
     takenColors: Set<PlayerColor>,
+    countdownActive: Boolean,
     onNameChange: (String) -> Unit,
     onColorChange: (PlayerColor) -> Unit,
     onReadyToggle: () -> Unit
 ) {
-    val canBeReady = slot.name.isNotBlank()
+    // Waehrend des 3-2-1-Countdowns ist der "Bereit"-Button gesperrt.
+    // Der User kann sein "Bereit" nicht mehr zuruecknehmen, sobald der
+    // Spielstart unmittelbar bevorsteht -- so vermeiden wir, dass er
+    // im Spiel landet, obwohl er kurz vorher noch "nicht bereit"
+    // geklickt hatte.
+    val canBeReady = slot.name.isNotBlank() && !countdownActive
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/components/LocalPlayerSlotCard.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/components/LocalPlayerSlotCard.kt
@@ -54,6 +54,7 @@ fun LocalPlayerSlotCard(
     slot: PlayerSlot,
     takenColors: Set<PlayerColor>,
     countdownActive: Boolean,
+    joinedServer: Boolean,
     onNameChange: (String) -> Unit,
     onColorChange: (PlayerColor) -> Unit,
     onReadyToggle: () -> Unit
@@ -112,7 +113,7 @@ fun LocalPlayerSlotCard(
             value = slot.name,
             onValueChange = onNameChange,
             singleLine = true,
-            enabled = !slot.ready,
+            enabled = !slot.ready && !joinedServer,
             keyboardOptions = KeyboardOptions.Default,
             label = {
                 Text(stringResource(R.string.waiting_your_name), style = TextStyle(fontSize = 12.sp))
@@ -157,7 +158,7 @@ fun LocalPlayerSlotCard(
                 ColorSeal(
                     color = color,
                     selected = slot.color == color,
-                    disabled = color in takenColors || slot.ready,
+                    disabled = color in takenColors || slot.ready || joinedServer,
                     onClick = { onColorChange(color) }
                 )
             }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/components/LocalPlayerSlotCard.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/components/LocalPlayerSlotCard.kt
@@ -59,12 +59,12 @@ fun LocalPlayerSlotCard(
     onColorChange: (PlayerColor) -> Unit,
     onReadyToggle: () -> Unit
 ) {
-    // Waehrend des 3-2-1-Countdowns ist der "Bereit"-Button gesperrt.
-    // Der User kann sein "Bereit" nicht mehr zuruecknehmen, sobald der
-    // Spielstart unmittelbar bevorsteht -- so vermeiden wir, dass er
-    // im Spiel landet, obwohl er kurz vorher noch "nicht bereit"
-    // geklickt hatte.
-    val canBeReady = slot.name.isNotBlank() && !countdownActive
+    // Der Bereit-Button ist gesperrt sobald:
+    //  - der Slot bereits ready ist: Server kennt keinen "leave"-Endpoint,
+    //    daher koennen wir das Ready nicht zurueckziehen, ohne Inkonsistenz
+    //    zu erzeugen. Wer raus will, nutzt den BACK-Button.
+    //  - der 3-2-1-Countdown laeuft: kein Last-Second-Cancel mehr moeglich.
+    val canBeReady = slot.name.isNotBlank() && !countdownActive && !slot.ready
 
     Column(
         modifier = Modifier

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyStateTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyStateTest.kt
@@ -3,6 +3,7 @@ package at.aau.serg.websocketbrokerdemo.ui.waiting
 import at.aau.serg.websocketbrokerdemo.ui.waiting.model.PlayerSlot
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -44,5 +45,11 @@ class WaitingLobbyStateTest {
     fun `default state has countdownComplete false`() {
         val state = WaitingLobbyState()
         assertFalse(state.countdownComplete)
+    }
+
+    @Test
+    fun `default state has no errorMessage`() {
+        val state = WaitingLobbyState()
+        assertNull(state.errorMessage)
     }
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyStateTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyStateTest.kt
@@ -39,4 +39,10 @@ class WaitingLobbyStateTest {
         val state = WaitingLobbyState(countdown = -1)
         assertFalse(state.isCountdownActive)
     }
+
+    @Test
+    fun `default state has countdownComplete false`() {
+        val state = WaitingLobbyState()
+        assertFalse(state.countdownComplete)
+    }
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.websocketbrokerdemo.ui.waiting
 
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
 import at.aau.serg.websocketbrokerdemo.ui.waiting.model.SlotStatus
@@ -108,7 +109,7 @@ class WaitingLobbyViewModelTest {
         Dispatchers.setMain(standardDispatcher)
 
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
-        vm.applyRemoteState(listOf("Borian"))
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         vm.onReadyToggle(slotId = 0)
         testScheduler.runCurrent()
         assertTrue(vm.state.value.isCountdownActive)
@@ -171,7 +172,12 @@ class WaitingLobbyViewModelTest {
     @Test
     fun `applyRemoteState fills empty slots with remote player names`() {
         val vm = WaitingLobbyViewModel(GameMode.BATTLEFIELD_PEAKS)
-        vm.applyRemoteState(listOf("Borian", "Cassia"))
+        vm.applyRemoteState(
+            listOf(
+                Player(name = "Borian", color = PlayerColor.BLUE),
+                Player(name = "Cassia", color = PlayerColor.GREEN)
+            )
+        )
 
         val slots = vm.state.value.slots
         assertEquals("Borian", slots[1].name)
@@ -181,19 +187,28 @@ class WaitingLobbyViewModelTest {
     }
 
     @Test
-    fun `applyRemoteState assigns unique colors to remote players`() {
+    fun `applyRemoteState uses the colors from the server`() {
         val vm = WaitingLobbyViewModel(GameMode.BATTLEFIELD_PEAKS)
-        vm.applyRemoteState(listOf("Borian", "Cassia", "Domitian"))
+        vm.applyRemoteState(
+            listOf(
+                Player(name = "Borian", color = PlayerColor.BLUE),
+                Player(name = "Cassia", color = PlayerColor.GREEN),
+                Player(name = "Domitian", color = PlayerColor.YELLOW)
+            )
+        )
 
         val slots = vm.state.value.slots
-        val colors = slots.map { it.color }
-        assertEquals(4, colors.toSet().size)
+        // Slots 1..3 spiegeln die Server-Farben wider, nicht eine
+        // client-seitige Vergabe.
+        assertEquals(PlayerColor.BLUE, slots[1].color)
+        assertEquals(PlayerColor.GREEN, slots[2].color)
+        assertEquals(PlayerColor.YELLOW, slots[3].color)
     }
 
     @Test
     fun `applyRemoteState empties slots when remote player leaves`() {
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
-        vm.applyRemoteState(listOf("Borian"))
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         assertEquals(SlotStatus.Player, vm.state.value.slots[1].status)
 
         vm.applyRemoteState(emptyList())
@@ -217,7 +232,7 @@ class WaitingLobbyViewModelTest {
         Dispatchers.setMain(standardDispatcher)
 
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
-        vm.applyRemoteState(listOf("Borian"))
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         vm.onReadyToggle(slotId = 0)
         testScheduler.runCurrent()
 
@@ -231,7 +246,7 @@ class WaitingLobbyViewModelTest {
         Dispatchers.setMain(standardDispatcher)
 
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
-        vm.applyRemoteState(listOf("Borian"))
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         vm.onReadyToggle(slotId = 0)
         testScheduler.runCurrent()
 
@@ -257,7 +272,7 @@ class WaitingLobbyViewModelTest {
         Dispatchers.setMain(standardDispatcher)
 
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
-        vm.applyRemoteState(listOf("Borian"))
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         vm.onReadyToggle(slotId = 0)
         testScheduler.runCurrent()
         assertTrue(vm.state.value.isCountdownActive)
@@ -276,7 +291,7 @@ class WaitingLobbyViewModelTest {
         Dispatchers.setMain(standardDispatcher)
 
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
-        vm.applyRemoteState(listOf("Borian"))
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         vm.onReadyToggle(slotId = 0)
         testScheduler.runCurrent()
         assertFalse(vm.state.value.countdownComplete)
@@ -293,7 +308,7 @@ class WaitingLobbyViewModelTest {
         Dispatchers.setMain(standardDispatcher)
 
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
-        vm.applyRemoteState(listOf("Borian"))
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         vm.onReadyToggle(slotId = 0)
         testScheduler.runCurrent()
 
@@ -324,7 +339,7 @@ class WaitingLobbyViewModelTest {
         Dispatchers.setMain(standardDispatcher)
 
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
-        vm.applyRemoteState(listOf("Borian"))
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         vm.onReadyToggle(slotId = 0)
         testScheduler.runCurrent()
         assertTrue(vm.state.value.isCountdownActive)

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
@@ -393,9 +393,12 @@ class WaitingLobbyViewModelTest {
         vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
         vm.onReadyToggle(slotId = 0)
         testScheduler.runCurrent()
+        assertTrue(vm.state.value.isCountdownActive)
 
-        // User klickt Ready wieder weg -> Countdown wird gecancelt
-        vm.onReadyToggle(slotId = 0)
+        // Remote-Spieler verlaesst den Raum -> Countdown wird gecancelt
+        // (onReadyToggle waere kein gueltiger Cancel-Pfad mehr, weil der
+        // Ready-Lock weitere Klicks ignoriert, sobald der User ready ist).
+        vm.applyRemoteState(emptyList())
         testScheduler.runCurrent()
 
         assertFalse(vm.state.value.countdownComplete)

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
@@ -137,6 +137,30 @@ class WaitingLobbyViewModelTest {
         assertNull(vm.state.value.errorMessage)
     }
 
+    @Test
+    fun `markJoinedServer sets joinedServer to true`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        assertFalse(vm.state.value.joinedServer)
+
+        vm.markJoinedServer()
+
+        assertTrue(vm.state.value.joinedServer)
+    }
+
+    @Test
+    fun `markJoinedServer is idempotent`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.markJoinedServer()
+        val firstState = vm.state.value
+
+        vm.markJoinedServer()
+        val secondState = vm.state.value
+
+        // Zweiter Aufruf gibt den gleichen State-Snapshot zurueck --
+        // kein unnoetiges Recompose oder maybeStartCountdown-Re-Trigger.
+        assertEquals(firstState, secondState)
+    }
+
     // ---- User-Aktionen -------------------------------------------------
 
     @Test

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
@@ -285,7 +285,7 @@ class WaitingLobbyViewModelTest {
     }
 
     @Test
-    fun `countdown cancels when a player goes back to not-ready`() = runTest {
+    fun `countdown cancels when a remote player leaves`() = runTest {
         val standardDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
         Dispatchers.resetMain()
         Dispatchers.setMain(standardDispatcher)
@@ -296,11 +296,37 @@ class WaitingLobbyViewModelTest {
         testScheduler.runCurrent()
         assertTrue(vm.state.value.isCountdownActive)
 
-        vm.onReadyToggle(slotId = 0)
+        // Remote-Spieler verlaesst den Raum -> Server broadcastet einen
+        // GameState ohne ihn, applyRemoteState raeumt Slot 1 auf -> der
+        // Countdown wird gecancelt, weil nicht mehr alle Slots besetzt
+        // und bereit sind.
+        vm.applyRemoteState(emptyList())
         testScheduler.runCurrent()
 
         assertEquals(-1, vm.state.value.countdown)
         assertFalse(vm.state.value.isCountdownActive)
+    }
+
+    @Test
+    fun `onReadyToggle is ignored while countdown is active`() = runTest {
+        val standardDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        Dispatchers.resetMain()
+        Dispatchers.setMain(standardDispatcher)
+
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.BLUE)))
+        vm.onReadyToggle(slotId = 0)
+        testScheduler.runCurrent()
+        assertTrue(vm.state.value.isCountdownActive)
+
+        // Klick auf "nicht bereit" waehrend der Countdown laeuft soll
+        // ignoriert werden, damit der User nicht im letzten Moment
+        // ausgesteigt wird, obwohl der Server schon Auto-Start auslost hat.
+        vm.onReadyToggle(slotId = 0)
+        testScheduler.runCurrent()
+
+        assertTrue(vm.localReady)
+        assertTrue(vm.state.value.isCountdownActive)
     }
 
     @Test

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
@@ -354,6 +354,19 @@ class WaitingLobbyViewModelTest {
     }
 
     @Test
+    fun `onReadyToggle is ignored when player is already ready`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.onReadyToggle(slotId = 0)
+        assertTrue(vm.localReady)
+
+        // Zweiter Klick soll ignoriert werden -- ready bleibt true.
+        // Server kennt keinen "leave"-Endpoint, daher kein Zurueck.
+        vm.onReadyToggle(slotId = 0)
+
+        assertTrue(vm.localReady)
+    }
+
+    @Test
     fun `countdownComplete becomes true after countdown finishes`() = runTest {
         val standardDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
         Dispatchers.resetMain()

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -88,6 +89,50 @@ class WaitingLobbyViewModelTest {
         val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
         vm.onReadyToggle(slotId = 0)
         assertTrue(vm.localReady)
+    }
+
+    @Test
+    fun `clearLocalReady sets local slot ready to false`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.onReadyToggle(slotId = 0)
+        assertTrue(vm.localReady)
+
+        vm.clearLocalReady()
+        assertFalse(vm.localReady)
+    }
+
+    @Test
+    fun `clearLocalReady cancels a running countdown`() = runTest {
+        val standardDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        Dispatchers.resetMain()
+        Dispatchers.setMain(standardDispatcher)
+
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.applyRemoteState(listOf("Borian"))
+        vm.onReadyToggle(slotId = 0)
+        testScheduler.runCurrent()
+        assertTrue(vm.state.value.isCountdownActive)
+
+        vm.clearLocalReady()
+        testScheduler.runCurrent()
+        assertFalse(vm.state.value.isCountdownActive)
+    }
+
+    // ---- Fehler-Handling -----------------------------------------------
+
+    @Test
+    fun `showError sets the errorMessage`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.showError("Test-Fehler")
+        assertEquals("Test-Fehler", vm.state.value.errorMessage)
+    }
+
+    @Test
+    fun `clearError removes the errorMessage`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.showError("Test-Fehler")
+        vm.clearError()
+        assertNull(vm.state.value.errorMessage)
     }
 
     // ---- User-Aktionen -------------------------------------------------

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -203,6 +204,24 @@ class WaitingLobbyViewModelTest {
         assertEquals(PlayerColor.BLUE, slots[1].color)
         assertEquals(PlayerColor.GREEN, slots[2].color)
         assertEquals(PlayerColor.YELLOW, slots[3].color)
+    }
+
+    @Test
+    fun `applyRemoteState reassigns local color if it collides with remote`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        // Lokaler Slot 0 startet mit RED (default).
+        // Remote Player hat auch RED -> Auto-Reassign muss greifen.
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.RED)))
+        assertNotEquals(PlayerColor.RED, vm.localColor)
+    }
+
+    @Test
+    fun `applyRemoteState does not reassign local color when user is ready`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.onReadyToggle(slotId = 0)   // user wird ready mit default RED
+        vm.applyRemoteState(listOf(Player(name = "Borian", color = PlayerColor.RED)))
+        // Soll NICHT geaendert werden -- der User hat bewusst gewaehlt.
+        assertEquals(PlayerColor.RED, vm.localColor)
     }
 
     @Test

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModelTest.kt
@@ -77,6 +77,19 @@ class WaitingLobbyViewModelTest {
         assertEquals(PlayerColor.GREEN, vm.localColor)
     }
 
+    @Test
+    fun `localReady is false initially`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        assertFalse(vm.localReady)
+    }
+
+    @Test
+    fun `localReady becomes true after onReadyToggle`() {
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.onReadyToggle(slotId = 0)
+        assertTrue(vm.localReady)
+    }
+
     // ---- User-Aktionen -------------------------------------------------
 
     @Test
@@ -209,6 +222,41 @@ class WaitingLobbyViewModelTest {
 
         assertEquals(-1, vm.state.value.countdown)
         assertFalse(vm.state.value.isCountdownActive)
+    }
+
+    @Test
+    fun `countdownComplete becomes true after countdown finishes`() = runTest {
+        val standardDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        Dispatchers.resetMain()
+        Dispatchers.setMain(standardDispatcher)
+
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.applyRemoteState(listOf("Borian"))
+        vm.onReadyToggle(slotId = 0)
+        testScheduler.runCurrent()
+        assertFalse(vm.state.value.countdownComplete)
+
+        advanceTimeBy(3500)
+        testScheduler.runCurrent()
+        assertTrue(vm.state.value.countdownComplete)
+    }
+
+    @Test
+    fun `countdownComplete resets to false when countdown cancels`() = runTest {
+        val standardDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        Dispatchers.resetMain()
+        Dispatchers.setMain(standardDispatcher)
+
+        val vm = WaitingLobbyViewModel(GameMode.DUAL_VALLEY)
+        vm.applyRemoteState(listOf("Borian"))
+        vm.onReadyToggle(slotId = 0)
+        testScheduler.runCurrent()
+
+        // User klickt Ready wieder weg -> Countdown wird gecancelt
+        vm.onReadyToggle(slotId = 0)
+        testScheduler.runCurrent()
+
+        assertFalse(vm.state.value.countdownComplete)
     }
 
     @Test


### PR DESCRIPTION
## Was dieser PR macht

Fixt mehrere UX- und Konsistenz-Probleme in der Wartelobby. Closes #151.

## Hauptänderungen

- **Lobby-Flow:** `joinGame` erst beim Ready-Klick (mit gewähltem Namen +
  Farbe), sichtbarer 3-2-1-Countdown vor dem GameScreen
- **Server-driven colors:** `applyRemoteState` übernimmt jetzt die Farben
  1:1 aus dem Server-GameState; Auto-Reassign bei Default-Kollision
  (beide RED), solange der User noch nicht ready ist
- **Error-Handling:** `COLOR_ALREADY_TAKEN` setzt den lokalen Ready
  zurück + zeigt Snackbar — User kann Farbe wechseln und neu Ready klicken
- **Stale-State-Cleanup:** beim Erstellen/Beitreten eines neuen Raums
  werden `gameState` und `lastError` resettet → keine Alt-Spieler in der
  neuen Lobby
- **Ready- und Identity-Lock:** sobald der Server den Spieler bestätigt
  hat, sind Name + Farbe + Ready gesperrt — verhindert Server-
  Inkonsistenzen (Server hat keinen Leave-Endpoint). Wer raus will,
  nutzt BACK

## Tests

WaitingLobbyViewModel + WaitingLobbyState voll abgedeckt: localReady,
countdownComplete, error handling, markJoinedServer, applyRemoteState
(Server-Farben + Auto-Reassign), onReadyToggle (Lock during countdown +
when ready).

Composables sind nicht mit JVM-Unit-Tests testbar (keine Compose-UI-Tests
im Projekt).

## Manuell getestet

2 und 3 Geräte: Create + Join via Code, Color-Konflikt mit Recovery,
BACK + neuer Raum, Spielstart bei allen gleichzeitig.