### PR TITLE
Remove unused random join lobby code

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogic.kt
@@ -43,18 +43,6 @@ object LobbyRoomLogic {
             listOf(LobbyEffect.ShowError("Kein Raum mit Code '$code' gefunden"))
         }
 
-    /** Effekte fuer das Ergebnis eines joinRandom-Aufrufs. */
-    fun effectsForJoinRandomResult(room: RoomDTO?): List<LobbyEffect> =
-        if (room != null && room.roomId.isNotBlank()) {
-            listOf(
-                LobbyEffect.SetRoomId(room.roomId),
-                LobbyEffect.SetJoinCode(room.joinCode),
-                LobbyEffect.NavigateToWaiting,
-            )
-        } else {
-            listOf(LobbyEffect.ShowError("Kein freier Raum gefunden"))
-        }
-
     /**
      * Prueft, ob ein Join-Versuch ueberhaupt gestartet werden darf.
      * Wird vom ViewModel als Gate vor dem API-Call genutzt -- damit

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.GroupAdd
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.CircularProgressIndicator
@@ -152,16 +151,6 @@ fun LobbyScreen(
                     subtitle = stringResource(R.string.lobby_join_with_code_sub),
                     sealColor = SealColor.Blue,
                     onClick = { viewModel.openJoinDialog() }
-                )
-                ActionCard(
-                    icon = Icons.Filled.Casino,
-                    title = stringResource(R.string.lobby_join_random),
-                    subtitle = stringResource(R.string.lobby_join_random_sub),
-                    sealColor = SealColor.Gold,
-                    onClick = {
-                        // TODO: Implement join random logic if needed
-                        navController.navigate(waitingScreen.route)
-                    }
                 )
             }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -51,12 +51,10 @@
     <string name="lobby_create_private_sub">Versiegelte Schlacht mit Verbündeten</string>
     <string name="lobby_join_with_code">Mit Code beitreten</string>
     <string name="lobby_join_with_code_sub">Gib das Siegel eines Verbündeten ein</string>
-    <string name="lobby_join_random">Zufällig beitreten</string>
-    <string name="lobby_join_random_sub">Wirf die Würfel des Schicksals</string>
 
     <!-- Code-Dialog -->
     <string name="dialog_enter_code">Schlacht-Siegel eingeben</string>
-    <string name="dialog_enter_code_sub">4 bis 8 Zeichen, von deinem Verbündeten</string>
+    <string name="dialog_enter_code_sub">6 Zeichen, von deinem Verbündeten</string>
 
     <!-- Wartelobby -->
     <string name="waiting_headline">— VERSAMMLUNG DER GENERÄLE —</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -19,6 +19,8 @@
     <!-- MainMenu -->
     <string name="menu_info">Information</string>
     <string name="menu_choose_battlefield">WÄHLE DEIN SCHLACHTFELD</string>
+
+    <!--suppress PluralsCandidate -->
     <string name="menu_player_count">%d Spieler</string>
 
     <!-- Spielmodi -->
@@ -65,7 +67,6 @@
     <string name="waiting_not_ready">NICHT BEREIT</string>
     <string name="waiting_empty_slot">Warte auf Verbündeten…</string>
     <string name="waiting_remote_ally">Verbundener Verbündeter</string>
-    <string name="waiting_bot_ally">Bot-Verbündeter</string>
 
     <!-- DE / Default -->
     <string name="hud_per_round">/ Runde</string>
@@ -85,7 +86,9 @@
     <string name="cheat_steal_yes">Stehlen</string>
     <string name="cheat_steal_no">Lass los</string>
 
+    <!--suppress PluralsCandidate -->
     <string name="cheat_waiting_won">Du wuerdest %1$d Gold gewinnen!</string>
+    <!--suppress PluralsCandidate -->
     <string name="cheat_waiting_lost">Du wuerdest %1$d Gold verlieren!</string>
     <string name="cheat_waiting_subtitle">Aber pass auf — vielleicht wirst du beklaut.</string>
     <string name="cheat_waiting_for_opponent">Warte auf Gegner…</string>
@@ -96,7 +99,7 @@
     <string name="unit_infantry">Infanterie</string>
     <string name="unit_archer">Bogenschuetze</string>
     <string name="unit_cavalry">Kavallerie</string>
-    <string name="placement_choose_cell">Waehle ein Feld fuer deine %1$s</string>
+    <string name="placement_choose_cell">Wähle ein Feld für deine %1$s</string>
 
     <string name="waiting_room_id">SCHLACHT-SIEGEL: %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <!-- MainMenu -->
     <string name="menu_info">Information</string>
     <string name="menu_choose_battlefield">CHOOSE YOUR BATTLEFIELD</string>
+
+    <!--suppress PluralsCandidate -->
     <string name="menu_player_count">%d players</string>
 
     <!-- Game modes -->
@@ -65,7 +67,6 @@
     <string name="waiting_not_ready">NOT READY</string>
     <string name="waiting_empty_slot">Awaiting ally…</string>
     <string name="waiting_remote_ally">Connected ally</string>
-    <string name="waiting_bot_ally">Bot ally</string>
 
     <!-- EN / values-en/strings.xml -->
     <string name="hud_per_round">/ round</string>
@@ -85,7 +86,9 @@
     <string name="cheat_steal_yes">Steal</string>
     <string name="cheat_steal_no">Let it go</string>
 
+    <!--suppress PluralsCandidate -->
     <string name="cheat_waiting_won">You would gain %1$d gold!</string>
+    <!--suppress PluralsCandidate -->
     <string name="cheat_waiting_lost">You would lose %1$d gold!</string>
     <string name="cheat_waiting_subtitle">But beware — you might get robbed.</string>
     <string name="cheat_waiting_for_opponent">Waiting for opponent…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,12 +51,10 @@
     <string name="lobby_create_private_sub">Forge a sealed war with friends</string>
     <string name="lobby_join_with_code">Join with Code</string>
     <string name="lobby_join_with_code_sub">Enter the seal of an ally</string>
-    <string name="lobby_join_random">Join Random Battle</string>
-    <string name="lobby_join_random_sub">Throw the dice of fate</string>
 
     <!-- Code dialog -->
     <string name="dialog_enter_code">Enter Battle Seal</string>
-    <string name="dialog_enter_code_sub">4 to 8 characters, sent by your ally</string>
+    <string name="dialog_enter_code_sub">6 characters, sent by your ally</string>
 
     <!-- Waiting Lobby -->
     <string name="waiting_headline">— ASSEMBLY OF GENERALS —</string>

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogicTest.kt
@@ -82,30 +82,6 @@ class LobbyRoomLogicTest {
     }
 
     @Test
-    fun `effectsForJoinRandomResult returns success effects when room is valid`() {
-        val room = RoomDTO(
-            roomId = "uuid-random",
-            joinCode = "RAND12",
-            mode = GameMode.DUAL_VALLEY
-        )
-        val effects = LobbyRoomLogic.effectsForJoinRandomResult(room)
-
-        assertEquals(3, effects.size)
-        assertTrue(effects.any { it is LobbyEffect.SetRoomId && it.roomId == "uuid-random" })
-        assertTrue(effects.any { it is LobbyEffect.SetJoinCode && it.joinCode == "RAND12" })
-        assertTrue(effects.any { it is LobbyEffect.NavigateToWaiting })
-    }
-
-    @Test
-    fun `effectsForJoinRandomResult returns error when room is null`() {
-        val effects = LobbyRoomLogic.effectsForJoinRandomResult(null)
-
-        assertEquals(1, effects.size)
-        val effect = effects[0] as LobbyEffect.ShowError
-        assertTrue(effect.message.contains("Kein freier Raum"))
-    }
-
-    @Test
     fun `canAttemptJoin returns state canJoin`() {
         // JoinByCodeLogic.isValid now requires exactly 6 chars
         val stateJoinable = LobbyState(code = "123456")


### PR DESCRIPTION
## Was dieser PR macht
Räumt das nicht funktionierende "Join Random Battle"-Feature aus dem Lobby-Flow. Der Code war ein Leftover, das durch einen früheren Merge-Konflikt wieder eingeführt wurde.

## Problem
Die Casino-`ActionCard` im LobbyScreen navigierte direkt zur Wartelobby ohne vorher einen Raum beim Server zu erstellen oder zu finden → `session.activeRoomId` blieb leer → der User landete in einer Wartelobby ohne gültigen Raum. PR #147 sollte das ursprünglich entfernen, der Code kam aber durch einen späteren Merge zurück.

## Änderungen
- `LobbyScreen.kt` — Casino-`ActionCard` und Casino-Import entfernt
- `LobbyRoomLogic.kt` — ungenutzte Funktion `effectsForJoinRandomResult` entfernt
- `LobbyRoomLogicTest.kt` — die zwei zugehörigen Tests entfernt
- `values/strings.xml` + `values-de/strings.xml` — Strings `lobby_join_random` und `lobby_join_random_sub` entfernt
- Bonus: Code-Length-Text im Join-Dialog von "4 bis 8 Zeichen" auf "6 Zeichen" korrigiert (entspricht jetzt der tatsächlichen Code-Länge)

## Tests
Bestehende `LobbyRoomLogicTest`-Tests für `effectsForCreateResult` und `effectsForJoinByCodeResult` laufen unverändert weiter. Build ist grün.

## Manuell getestet
- Mode wählen → Lobby öffnet sich → es erscheinen nur noch zwei ActionCards (Create Private + Join with Code)
- Create + Join über Code funktionieren wie bisher