### PR TITLE
Fix GameScreen mode by deriving it from the server GameState

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/mainmenu/GameModeMapping.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/mainmenu/GameModeMapping.kt
@@ -1,0 +1,20 @@
+package at.aau.serg.websocketbrokerdemo.ui.mainmenu
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameMode as ServerGameMode
+
+/**
+ * Uebersetzt den Server-GameMode in den UI-GameMode.
+ *
+ * Beide Enums tragen die gleichen Namen, aber leben in unterschied-
+ * lichen Schichten: der Server-Enum kommt aus dem Daten-Layer
+ * (deserialisiert aus dem GameState-JSON), der UI-Enum traegt
+ * zusaetzlich Drawable- und String-Resources.
+ *
+ * Die `when`-Variante ist exhaustive -- wenn der Server spaeter einen
+ * vierten Modus bekommt, fordert der Compiler hier eine Anpassung an.
+ */
+fun ServerGameMode.toUiMode(): GameMode = when (this) {
+    ServerGameMode.DUAL_VALLEY -> GameMode.DUAL_VALLEY
+    ServerGameMode.TRIAD_OUTPOST -> GameMode.TRIAD_OUTPOST
+    ServerGameMode.BATTLEFIELD_PEAKS -> GameMode.BATTLEFIELD_PEAKS
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/navigation/AppNavHost.kt
@@ -15,6 +15,7 @@ import at.aau.serg.websocketbrokerdemo.ui.home.HomeScreen
 import at.aau.serg.websocketbrokerdemo.ui.lobby_modes.LobbyScreen
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.MainMenuScreen
+import at.aau.serg.websocketbrokerdemo.ui.mainmenu.toUiMode
 import at.aau.serg.websocketbrokerdemo.ui.settings.SettingsScreen
 import at.aau.serg.websocketbrokerdemo.ui.waiting.WaitingLobbyScreen
 
@@ -82,8 +83,14 @@ fun AppNavHost(
         }
 
         composable(Screen.Game.route) {
-            // TODO: Modus dynamisch ableiten sobald Server ihn liefert.
-            GameScreen(session = session, mode = GameMode.BATTLEFIELD_PEAKS)
+            // Modus aus dem Server-GameState lesen. Solange noch kein
+            // Broadcast eingetroffen ist, faellt der Modus auf
+            // DUAL_VALLEY zurueck -- der GameScreen rendert dann ein
+            // gueltiges Board, das mit dem ersten echten Update auf den
+            // richtigen Modus springt.
+            val mode = session.gameState.value?.gameMode?.toUiMode()
+                ?: GameMode.DUAL_VALLEY
+            GameScreen(session = session, mode = mode)
         }
     }
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/mainmenu/GameModeMappingTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/mainmenu/GameModeMappingTest.kt
@@ -1,0 +1,31 @@
+package at.aau.serg.websocketbrokerdemo.ui.mainmenu
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameMode as ServerGameMode
+
+/**
+ * Tests fuer das Server-zu-UI GameMode-Mapping.
+ *
+ * Pure JVM-Tests -- die Mapping-Funktion ist eine reine Extension
+ * ohne Compose- oder Android-Abhaengigkeiten, damit hier sauber
+ * abgesichert werden kann, dass jeder Server-Modus dem richtigen
+ * UI-Modus zugeordnet wird.
+ */
+class GameModeMappingTest {
+
+    @Test
+    fun `DUAL_VALLEY maps to DUAL_VALLEY`() {
+        assertEquals(GameMode.DUAL_VALLEY, ServerGameMode.DUAL_VALLEY.toUiMode())
+    }
+
+    @Test
+    fun `TRIAD_OUTPOST maps to TRIAD_OUTPOST`() {
+        assertEquals(GameMode.TRIAD_OUTPOST, ServerGameMode.TRIAD_OUTPOST.toUiMode())
+    }
+
+    @Test
+    fun `BATTLEFIELD_PEAKS maps to BATTLEFIELD_PEAKS`() {
+        assertEquals(GameMode.BATTLEFIELD_PEAKS, ServerGameMode.BATTLEFIELD_PEAKS.toUiMode())
+    }
+}


### PR DESCRIPTION
## Was dieser PR macht

Fixt einen Bug, durch den der GameScreen unabhängig vom gewählten Modus immer das BATTLEFIELD_PEAKS-Layout gerendert hat.

## Problem
`AppNavHost` übergab dem `GameScreen` hardcoded `GameMode.BATTLEFIELD_PEAKS` — egal welcher Modus tatsächlich gespielt wurde.

Folge:
- DUAL_VALLEY (Server: 9×9) → App rendert 13×13 ❌
- TRIAD_OUTPOST (Server: 11×11) → App rendert 13×13 ❌
- BATTLEFIELD_PEAKS → passt zufällig

Einheiten landeten dadurch an falschen Bildschirmpositionen oder gingen außerhalb der Map verloren.

## Ziel
Den Modus aus dem Server-`gameState.gameMode` lesen und an den GameScreen weitergeben.

## Änderungen
- `GameModeMapping.kt` *(neu)* — Extension `toUiMode()` mappt den Server-Enum (`data.serverside.GameMode`) auf den UI-Enum (`ui.mainmenu.GameMode`). `when` ist exhaustive — wenn der Server später einen vierten Modus liefert, fordert der Compiler hier eine Anpassung
- `GameModeMappingTest.kt` *(neu)* — 3 Unit-Tests, einer pro Modus
- `AppNavHost.kt` — liest jetzt `session.gameState.value?.gameMode`, übersetzt mit `toUiMode()`, Fallback auf `DUAL_VALLEY` solange noch kein Broadcast da war. Der alte TODO-Kommentar ist obsolet und entfernt

## Akzeptanzkriterien
- [x] DUAL_VALLEY rendert 9×9-Board
- [x] TRIAD_OUTPOST rendert 11×11-Board
- [x] BATTLEFIELD_PEAKS rendert 13×13-Board

## Manuell getestet
Mit Geräten in allen drei Modi getestet — Board-Layout passt jetzt zum Server-State, Einheiten landen an den richtigen Positionen.