### PR TITLE
Subissue #123 farbliche feldmarkierungen

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexGrid.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexGrid.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import at.aau.serg.websocketbrokerdemo.data.serverside.Building
 import at.aau.serg.websocketbrokerdemo.data.serverside.BuildingType
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
@@ -19,6 +20,8 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
  * @param layout  Hex-Geometrie der aktuellen Karte
  * @param units   Liste der Einheiten (GameUnit) fuers Rendering
  * @param buildings Liste der Gebaeude (Building) fuers Rendering
+ * @param fields  Hex-Felder mit Besitzer-Info fuer die Einfaerbung
+ *                eroberter Zellen (subissue #123)
  * @param players Volle Spieler-Liste fuer das Farb-Mapping
  */
 @Composable
@@ -26,6 +29,7 @@ fun HexGrid(
     layout: MapLayout,
     units: List<GameUnit>,
     buildings: List<Building>,
+    fields: List<Field>,
     players: List<Player>,
     modifier: Modifier = Modifier
 ) {
@@ -52,7 +56,7 @@ fun HexGrid(
 
     Canvas(modifier = modifier) {
         with(renderer) {
-            render(layout, units, buildings, players, unitPainters, buildingPainters)
+            render(layout, units, buildings, fields, players, unitPainters, buildingPainters)
         }
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexRenderer.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexRenderer.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.painter.Painter
 import at.aau.serg.websocketbrokerdemo.data.serverside.Building
 import at.aau.serg.websocketbrokerdemo.data.serverside.BuildingType
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
@@ -26,9 +27,16 @@ class HexRenderer {
     /**
      * Zeichnet alle Zellen und die darauf stehenden Einheiten/Gebaeude.
      *
+     * Reihenfolge pro Zelle: Fuellung eroberter Felder -> Hex-Rand ->
+     * Gebaeude -> Einheit, damit Rand und Icons immer ueber der Markierung liegen.
+     *
+     *
      * @param layout  Hex-Geometrie der aktuellen Karte
      * @param units   Liste der Einheiten (GameUnit)
      * @param buildings Liste der Gebaeude (Building)
+     * @param fields  Hex-Felder mit Besitzer-Info aus dem GameState;
+     *                eroberte Felder (owner != null) werden halbtransparent
+     *                in der Spielerfarbe gefuellt (subissue #123)
      * @param players Volle Spieler-Liste aus dem GameState fuer das
      *                Farb-Mapping
      * @param unitPainters Vorab geladene Painter fuer die Einheiten-Icons
@@ -38,16 +46,25 @@ class HexRenderer {
         layout: MapLayout,
         units: List<GameUnit>,
         buildings: List<Building>,
+        fields: List<Field>,
         players: List<Player>,
         unitPainters: Map<Pair<PlayerColor, UnitType>, Painter>,
         buildingPainters: Map<Pair<PlayerColor, BuildingType>, Painter>
     ) {
         val unitsByPosition = units.associateBy { it.x to it.y }
         val buildingsByPosition = buildings.associateBy { it.x to it.y }
+        val fieldsByPosition = fields.associateBy { it.x to it.y }
         val playerMap = players.associateBy { it.name }
 
         for ((col, row) in HexGridLogic.allCells(layout)) {
             val (cx, cy) = HexGridLogic.cellCenter(col, row, layout)
+
+            // Eroberte Felder zuerst fuellen, damit Rand und Icons
+            // darueber liegen
+            fieldsByPosition[col to row]?.owner?.let { owner ->
+                val fillColor = PlayerColorMap.cellFillFor(owner, players)
+                drawCellFill(cx, cy, layout.hexSize, fillColor)
+            }
 
             drawHex(cx, cy, layout.hexSize)
 
@@ -78,7 +95,6 @@ class HexRenderer {
         path.close()
         drawPath(path, color, style = Fill)
     }
-
 
     /** Einzelner Hex als geschlossener Pfad mit schwarzem Rand. */
     private fun DrawScope.drawHex(cx: Float, cy: Float, size: Float) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexRenderer.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexRenderer.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.painter.Painter
@@ -64,6 +65,20 @@ class HexRenderer {
             }
         }
     }
+
+    /**
+     * Fuellt ein Hex vollflaechig in der (bereits halbtransparenten)
+     * Besitzer-Farbe, siehe [PlayerColorMap.cellFillFor].
+     */
+    private fun DrawScope.drawCellFill(cx: Float, cy: Float, size: Float, color: Color) {
+        val path = Path()
+        HexGridLogic.hexCorners(cx, cy, size).forEachIndexed { i, (x, y) ->
+            if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        path.close()
+        drawPath(path, color, style = Fill)
+    }
+
 
     /** Einzelner Hex als geschlossener Pfad mit schwarzem Rand. */
     private fun DrawScope.drawHex(cx: Float, cy: Float, size: Float) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/PlayerColorMap.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/PlayerColorMap.kt
@@ -39,4 +39,21 @@ object PlayerColorMap {
 
     /** Direkt-Mapping von PlayerColor zu Compose-Farbe. */
     fun colorFor(color: PlayerColor): Color = color.main
+
+    /**
+     * -subissue #123
+     * Liefert die halbtransparente Füll-Farbe für ein erobertes Feld.
+     *
+     * Gleiche Namens-Auflösung wie [colorFor], nur mit reduziertem
+     * Alpha, damit der Karten-Hintergrund unter der Markierung sichtbar
+     * bleibt.
+     *
+     * @param playerName Spielername wie vom Server gemeldet
+     * @param players    Spieler-Liste aus dem aktuellen GameState
+     * @param alpha      Deckkraft der Fuellung (Default 0.5 = 50 %)
+     * @return Spielerfarbe (oder [DEFAULT_COLOR]) mit angewendetem Alpha
+     */
+    fun cellFillFor(playerName: String, players: List<Player>, alpha: Float = 0.5f): Color =
+        colorFor(playerName, players).copy(alpha = alpha)
+
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameMap.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameMap.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntSize
 import at.aau.serg.websocketbrokerdemo.data.serverside.Building
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.grid.HexGrid
@@ -26,6 +27,10 @@ import com.example.myapplication.R
 
 /**
  * Composable fuer die Spielkarte (Hintergrund + Hex-Grid + Kamera).
+ *
+ * Reicht die Hex-Felder (fields) mit Besitzer-Info ans [HexGrid]
+ * weiter, damit eroberte Zellen halbtransparent in der Spielerfarbe
+ * eingefaerbt werden (subissue #123).
  *
  * Background-Image liegt INNERHALB des cameraControls-Layers, damit
  * sich Hintergrund und Hex-Grid beim Zoomen gemeinsam bewegen --
@@ -46,6 +51,7 @@ fun GameMap(
     layout: MapLayout,
     units: List<GameUnit>,
     buildings: List<Building>,
+    fields: List<Field>,
     players: List<Player>,
     camera: CameraState,
     onCellTapped: (tapX: Float, tapY: Float, pixelToCell: (Float, Float) -> Pair<Int, Int>?) -> Unit,
@@ -80,6 +86,7 @@ fun GameMap(
                     layout = layout,
                     units = units,
                     buildings = buildings,
+                    fields = fields,
                     players = players,
                     modifier = Modifier.wrapContentSize()
                 )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -33,6 +33,8 @@ import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
  *
  * Reine UI-Schicht. Reicht den serverseitigen GameState an die
  * Sub-Composables weiter und delegiert Taps an das ViewModel.
+ * Die Hex-Felder (fields) gehen mit an die GameMap, damit eroberte
+ * Zellen in der Spielerfarbe markiert werden (subssue #123).
  *
  * Erhaelt den Spielmodus per Parameter, weil der Server bisher keine
  * Map-Konfiguration zurueck schickt -- das Frontend leitet das Brett
@@ -74,6 +76,7 @@ fun GameScreen(
             layout = layout,
             units = units,
             buildings = gameState?.buildings.orEmpty(),
+            fields = gameState?.fields.orEmpty(),
             players = players,
             camera = camera,
             onCellTapped = { tapX, tapY, pixelToCell ->

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/grid/HexRendererTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/grid/HexRendererTest.kt
@@ -2,9 +2,12 @@ package at.aau.serg.websocketbrokerdemo.grid
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.painter.Painter
 import at.aau.serg.websocketbrokerdemo.data.serverside.Building
 import at.aau.serg.websocketbrokerdemo.data.serverside.BuildingType
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
@@ -35,7 +38,7 @@ class HexRendererTest {
     fun setUp() {
         renderer = HexRenderer()
         scope = mockk(relaxed = true)
-        
+
         unitPainters = PlayerColor.entries.flatMap { color ->
             UnitType.entries.map { type ->
                 (color to type) to mockk<Painter>(relaxed = true)
@@ -54,10 +57,11 @@ class HexRendererTest {
     private fun draw(
         units: List<GameUnit> = emptyList(),
         buildings: List<Building> = emptyList(),
+        fields: List<Field> = emptyList(),
         players: List<Player> = emptyList()
     ) {
         with(renderer) {
-            scope.render(tinyLayout, units, buildings, players, unitPainters, buildingPainters)
+            scope.render(tinyLayout, units, buildings, fields, players, unitPainters, buildingPainters)
         }
     }
 
@@ -109,13 +113,56 @@ class HexRendererTest {
         }
     }
 
+    // ---- Feld-Markierungen (subissue #123) ----------------------------------
+
+    @Test
+    fun `fills owned fields exactly once`() {
+        val fields = listOf(Field(x = 0, y = 0, owner = "Alice"))
+
+        draw(fields = fields, players = listOf(alice))
+
+        // Genau EINE Fuellung (nur das eroberte Feld). Kein eq()-Vergleich
+        // der Farbe: Compose-Color ist eine value class, deren Argumente
+        // MockK nur als rohen Long aufzeichnet -- die konkrete 50%-Farbe
+        // ist durch PlayerColorMapTest.cellFillFor abgedeckt.
+        verify(exactly = 1) {
+            scope.drawPath(any(), any<Color>(), any(), eq(Fill), any(), any())
+        }
+    }
+
+    @Test
+    fun `does not fill neutral fields`() {
+        val fields = listOf(Field(x = 0, y = 0, owner = null))
+
+        draw(fields = fields, players = listOf(alice))
+
+        // nur die 4 Hex-Raender, keine zusaetzliche Fuellung
+        verify(exactly = 4) {
+            scope.drawPath(any(), any<Color>(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `draws fill before hex outline`() {
+        val fields = listOf(Field(x = 0, y = 0, owner = "Alice"))
+
+        draw(fields = fields, players = listOf(alice))
+
+        // Unterscheidung ueber den Zeichenstil (Fill vs. Stroke), weil
+        // Color-Argumente von MockK nicht per eq() vergleichbar sind.
+        verifyOrder {
+            scope.drawPath(any(), any<Color>(), any(), eq(Fill), any(), any())
+            scope.drawPath(any(), any<Color>(), any(), ofType<Stroke>(), any(), any())
+        }
+    }
+
     // ---- Rendering Order -----------------------------------------------
 
     @Test
     fun `draws buildings before units on the same cell`() {
         val buildings = listOf(Building(player = "Alice", x = 0, y = 0, type = BuildingType.CASTLE))
         val units = listOf(GameUnit(player = "Alice", x = 0, y = 0, type = UnitType.INFANTRY))
-        
+
         draw(units = units, buildings = buildings, players = listOf(alice))
 
         val castlePainter = buildingPainters[PlayerColor.RED to BuildingType.CASTLE]!!

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/grid/PlayerColorMapTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/grid/PlayerColorMapTest.kt
@@ -53,6 +53,30 @@ class PlayerColorMapTest {
     }
 
     @Test
+    fun `cellFillFor applies 50 percent alpha by default`() {
+        assertEquals(
+            PlayerColor.RED.main.copy(alpha = 0.5f),
+            PlayerColorMap.cellFillFor("Alice", allPlayers)
+        )
+    }
+
+    @Test
+    fun `cellFillFor respects custom alpha`() {
+        assertEquals(
+            PlayerColor.BLUE.main.copy(alpha = 0.25f),
+            PlayerColorMap.cellFillFor("Bob", allPlayers, alpha = 0.25f)
+        )
+    }
+
+    @Test
+    fun `cellFillFor falls back to translucent default color for unknown player`() {
+        assertEquals(
+            PlayerColorMap.DEFAULT_COLOR.copy(alpha = 0.5f),
+            PlayerColorMap.cellFillFor("Ghost", allPlayers)
+        )
+    }
+
+    @Test
     fun `colorFor is deterministic for same input`() {
         // Mehrfacher Aufruf gibt das gleiche Ergebnis (keine versteckte
         // State-Mutation).


### PR DESCRIPTION
## Description

This PR introduces the visual representation of field ownership on the game map. Hexes owned by a player are now rendered with a translucent tint matching their assigned player color, making the territorial board state immediately recognizable.

### Key Changes
* **State Propagation:** Threaded the `fields` list from `GameScreen` down through `GameMap` and `HexGrid` into the renderer. This is a pure pass-through mirroring the existing pattern used for buildings.
* **Color Handling:** Added a `cellFillFor` helper in `PlayerColorMap`. It reuses the existing lookup and applies an alpha blend (default 50% per the issue requirements), keeping `Color.copy` logic out of the callers. Unknown players safely fall back to a translucent `DEFAULT_COLOR`.
* **Rendering Order:** Updated `HexRenderer` to accept a new `fields` parameter and draw the ownership tint via `drawCellFill`. The fill is intentionally drawn **before** `drawHex` to ensure hex borders, units, and building icons stay crisp and completely visible on top.

---

## Related Issues
Closes #123

---


<details>
<summary><b>View detailed commit breakdown</b></summary>

1. **Add cellFillFor helper to PlayerColorMap (Issue #123)**
   * Reuses the existing colorFor lookup and applies an alpha (default 0.5 = 50% per the issue), so callers do not need to know about Color.copy. Unknown players fall back to a translucent DEFAULT_COLOR.
2. **Render translucent owner fill in HexRenderer (Issue #123)**
   * New `fields` parameter, fieldsByPosition lookup mirrors the existing units/buildings maps. drawCellFill is invoked BEFORE drawHex so the hex border and unit/building icons stay on top of the tint. Render order documented in the KDoc.
3. **Thread fields list through HexGrid, GameMap, GameScreen**
   * Pure pass-through, no logic. GameScreen reads `gameState?.fields.orEmpty()` and forwards it down to the renderer — same pattern already used for buildings.
4. **Add tests for cellFillFor and field rendering + added tests**
   * `PlayerColorMapTest`: default alpha, custom alpha, fallback for unknown player.
   * `HexRendererTest`: owned field gets exactly one fill, neutral field gets none, fill is drawn before the hex outline.
5. **Fix HexRendererTest: compare draw style instead of Color**
   * Compose Color is a value class; MockK records its arguments as raw Long, so `eq(Color(...))` never matches. Switched the two affected tests to `eq(Fill)` / `ofType<Stroke>()`. The concrete 50%-alpha colour value remains covered by `PlayerColorMapTest.cellFillFor`.

</details>