### PR TITLE
Feature units visual movement

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexGrid.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexGrid.kt
@@ -31,6 +31,7 @@ fun HexGrid(
     buildings: List<Building>,
     fields: List<Field>,
     players: List<Player>,
+    darkenedCells: Set<Pair<Int, Int>> = emptySet(),
     modifier: Modifier = Modifier
 ) {
     val renderer = remember { HexRenderer() }
@@ -56,7 +57,7 @@ fun HexGrid(
 
     Canvas(modifier = modifier) {
         with(renderer) {
-            render(layout, units, buildings, fields, players, unitPainters, buildingPainters)
+            render(layout, units, buildings, fields, players, unitPainters, buildingPainters, darkenedCells)
         }
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexGridLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexGridLogic.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.websocketbrokerdemo.grid
 
+import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
@@ -81,6 +82,26 @@ object HexGridLogic {
      * Etwas kleiner als der Hex selbst, damit Rand sichtbar bleibt.
      */
     fun unitRadius(size: Float): Float = size / 2.5f
+
+    /**
+     * Hex-Distanz zwischen zwei Zellen in offset-Koordinaten.
+     *
+     * Konvertiert intern in Cube-Koordinaten (odd-q, ungerade Spalten
+     * sind nach unten verschoben — passend zu [cellCenter]). Liefert die
+     * minimale Anzahl an Hex-Schritten zwischen den beiden Feldern.
+     */
+    fun hexDistance(col1: Int, row1: Int, col2: Int, row2: Int): Int {
+        val (ax, ay, az) = oddQToCube(col1, row1)
+        val (bx, by, bz) = oddQToCube(col2, row2)
+        return (abs(ax - bx) + abs(ay - by) + abs(az - bz)) / 2
+    }
+
+    private fun oddQToCube(col: Int, row: Int): Triple<Int, Int, Int> {
+        val x = col
+        val z = row - (col - (col and 1)) / 2
+        val y = -x - z
+        return Triple(x, y, z)
+    }
 
     /**
      * Iteriert alle Zellen einer Karte. Aktuell ein einfaches Rechteck;

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexRenderer.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexRenderer.kt
@@ -49,7 +49,8 @@ class HexRenderer {
         fields: List<Field>,
         players: List<Player>,
         unitPainters: Map<Pair<PlayerColor, UnitType>, Painter>,
-        buildingPainters: Map<Pair<PlayerColor, BuildingType>, Painter>
+        buildingPainters: Map<Pair<PlayerColor, BuildingType>, Painter>,
+        darkenedCells: Set<Pair<Int, Int>> = emptySet()
     ) {
         val unitsByPosition = units.associateBy { it.x to it.y }
         val buildingsByPosition = buildings.associateBy { it.x to it.y }
@@ -79,6 +80,17 @@ class HexRenderer {
                 val player = playerMap[unit.player]
                 val color = player?.color ?: PlayerColor.RED // Fallback
                 drawUnit(unit, color, unitPainters, cx, cy, layout.hexSize)
+            }
+        }
+
+        // Outside-Range-Overlay als letzter Schritt -- darunter sind
+        // Owner-Farbe, Hex-Rand und Einheiten/Gebaeude schon gezeichnet,
+        // der dunkle Overlay legt sich darueber und signalisiert
+        // "ausserhalb der Reichweite".
+        if (darkenedCells.isNotEmpty()) {
+            for ((col, row) in darkenedCells) {
+                val (cx, cy) = HexGridLogic.cellCenter(col, row, layout)
+                drawCellFill(cx, cy, layout.hexSize, Color(0f, 0f, 0f, 0.45f))
             }
         }
     }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameMap.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameMap.kt
@@ -55,6 +55,7 @@ fun GameMap(
     players: List<Player>,
     camera: CameraState,
     onCellTapped: (tapX: Float, tapY: Float, pixelToCell: (Float, Float) -> Pair<Int, Int>?) -> Unit,
+    darkenedCells: Set<Pair<Int, Int>> = emptySet(),
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -88,6 +89,7 @@ fun GameMap(
                     buildings = buildings,
                     fields = fields,
                     players = players,
+                    darkenedCells = darkenedCells,
                     modifier = Modifier.wrapContentSize()
                 )
             }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavController
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
+import at.aau.serg.websocketbrokerdemo.grid.HexGridLogic
 import at.aau.serg.websocketbrokerdemo.grid.MapLayouts
 import at.aau.serg.websocketbrokerdemo.network.GameSession
 import at.aau.serg.websocketbrokerdemo.ui.game.bottomhud.BottomHud
@@ -70,10 +71,22 @@ fun GameScreen(
 
     val units = gameState?.units.orEmpty()
     val players = gameState?.players.orEmpty()
+    val fields = gameState?.fields.orEmpty()
     val localName = session.localPlayerName.value
     val pendingGift = gameState?.pendingGift
     val currentTurn = gameState?.currentTurn
     val status = gameState?.status ?: GameStatus.WAITING_FOR_PLAYERS
+
+    // Wenn eine eigene Einheit selektiert ist, dunkle alle Felder ab,
+    // die NICHT in Reichweite sind. Range = 2 nur wenn die Einheit auf
+    // einem eigenen (Field.owner == player) Feld steht, sonst 1.
+    val darkenedCells: Set<Pair<Int, Int>> = uiState.selected?.let { selected ->
+        val reachable = GameScreenLogic.reachableCells(selected, fields, layout)
+        if (reachable.isEmpty()) emptySet()
+        else HexGridLogic.allCells(layout).toSet() -
+            reachable -
+            setOf(selected.x to selected.y)
+    } ?: emptySet()
 
     LaunchedEffect(status) {
         if (status == GameStatus.FINISHED) {
@@ -92,7 +105,7 @@ fun GameScreen(
             layout = layout,
             units = units,
             buildings = gameState?.buildings.orEmpty(),
-            fields = gameState?.fields.orEmpty(),
+            fields = fields,
             players = players,
             camera = camera,
             onCellTapped = { tapX, tapY, pixelToCell ->
@@ -100,7 +113,8 @@ fun GameScreen(
                 if (cell != null) {
                     viewModel.onCellTapped(cell.first, cell.second, units)
                 }
-            }
+            },
+            darkenedCells = darkenedCells
         )
 
         TopHud(

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogic.kt
@@ -1,9 +1,12 @@
 package at.aau.serg.websocketbrokerdemo.ui.game
 
 import androidx.compose.ui.unit.IntSize
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.Move
 import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
+import at.aau.serg.websocketbrokerdemo.grid.HexGridLogic
+import at.aau.serg.websocketbrokerdemo.grid.MapLayout
 
 /**
  * Pure Logik des GameScreens.
@@ -73,6 +76,13 @@ object GameScreenLogic {
         val clickedUnit = findClickableUnit(units, col, row)
 
         if (clickedUnit != null && clickedUnit.player == localName) {
+            // Die Hauptbasis kann sich nicht bewegen -> nicht selektierbar.
+            // Wir geben Ignore zurueck (nicht durchfallen lassen), damit
+            // ein Tap auf die eigene Basis nicht versehentlich einen
+            // ExecuteMove zur eigenen Basis ausloest.
+            if (clickedUnit.type == UnitType.BASE) {
+                return TapAction.Ignore
+            }
             return TapAction.Select(clickedUnit)
         }
 
@@ -106,5 +116,55 @@ object GameScreenLogic {
     fun isAttackMove(move: Move, units: List<GameUnit>, localName: String?): Boolean {
         val target = findClickableUnit(units, move.toX, move.toY) ?: return false
         return target.player != localName
+    }
+
+    /**
+     * Berechnet die Felder, auf die [unit] in diesem Zug ziehen kann.
+     *
+     * Reichweiten-Regel (Spec, Pfad-basiert):
+     *  - Entfernung 1: jede Zelle (eigen, neutral, feindlich) — der Zug
+     *    darf neutrale/feindliche Felder erobern, aber nur 1 Schritt weit.
+     *  - Entfernung 2: nur erreichbar, wenn ein gemeinsames Nachbarfeld
+     *    von Source und Target DEM SPIELER gehoert. Der zweite Schritt
+     *    darf dann auf ein beliebiges Feld (eigen / neutral / feindlich)
+     *    fuehren. Bild: "uebers eigene Gebiet marschieren und am Rand
+     *    erobern".
+     *  - BASE bewegt sich nicht.
+     *  - Bereits gezogene Einheit -> leer.
+     *
+     * Das eigene Stand-Feld der Einheit wird NICHT mit zurueckgegeben.
+     */
+    fun reachableCells(
+        unit: GameUnit,
+        fields: List<Field>,
+        layout: MapLayout
+    ): Set<Pair<Int, Int>> {
+        if (unit.hasMovedThisTurn) return emptySet()
+        if (unit.type == UnitType.BASE) return emptySet()
+        val ownedCells: Set<Pair<Int, Int>> = fields
+            .asSequence()
+            .filter { it.owner == unit.player }
+            .map { it.x to it.y }
+            .toSet()
+        val sx = unit.x
+        val sy = unit.y
+        val allCells = HexGridLogic.allCells(layout).toList()
+        // Eigene Felder die direkt neben der Quelle liegen -- das sind die
+        // moeglichen "Trittsteine" fuer den 2-Felder-Marsch.
+        val ownNeighbors = allCells.filter { (c, r) ->
+            (c to r) in ownedCells && HexGridLogic.hexDistance(sx, sy, c, r) == 1
+        }
+        return allCells
+            .filter { (col, row) ->
+                if (col == sx && row == sy) return@filter false
+                when (HexGridLogic.hexDistance(sx, sy, col, row)) {
+                    1 -> true
+                    2 -> ownNeighbors.any { (ic, ir) ->
+                        HexGridLogic.hexDistance(col, row, ic, ir) == 1
+                    }
+                    else -> false
+                }
+            }
+            .toSet()
     }
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/grid/HexGridLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/grid/HexGridLogicTest.kt
@@ -183,4 +183,52 @@ class HexGridLogicTest {
         assertTrue(cells.contains(1 to 0))
         assertTrue(cells.contains(1 to 1))
     }
+
+    // ---- hexDistance --------------------------------------------------
+
+    @Test
+    fun `hexDistance gleiche Zelle ist 0`() {
+        assertEquals(0, HexGridLogic.hexDistance(2, 3, 2, 3))
+    }
+
+    @Test
+    fun `hexDistance Nachbar in gleicher Spalte ist 1`() {
+        assertEquals(1, HexGridLogic.hexDistance(2, 2, 2, 3))
+        assertEquals(1, HexGridLogic.hexDistance(2, 2, 2, 1))
+    }
+
+    @Test
+    fun `hexDistance Nachbarn gerader Spalte ueber Spaltengrenze ist 1`() {
+        // (2,2) ist gerade Spalte: Nachbarn (1,1), (1,2), (3,1), (3,2)
+        assertEquals(1, HexGridLogic.hexDistance(2, 2, 1, 1))
+        assertEquals(1, HexGridLogic.hexDistance(2, 2, 1, 2))
+        assertEquals(1, HexGridLogic.hexDistance(2, 2, 3, 1))
+        assertEquals(1, HexGridLogic.hexDistance(2, 2, 3, 2))
+    }
+
+    @Test
+    fun `hexDistance Nachbarn ungerader Spalte ist 1`() {
+        // (1,1) ist ungerade Spalte (nach unten verschoben).
+        // Nachbarn: (0,1),(0,2),(2,1),(2,2),(1,0),(1,2)
+        assertEquals(1, HexGridLogic.hexDistance(1, 1, 0, 1))
+        assertEquals(1, HexGridLogic.hexDistance(1, 1, 0, 2))
+        assertEquals(1, HexGridLogic.hexDistance(1, 1, 2, 1))
+        assertEquals(1, HexGridLogic.hexDistance(1, 1, 2, 2))
+        assertEquals(1, HexGridLogic.hexDistance(1, 1, 1, 0))
+        assertEquals(1, HexGridLogic.hexDistance(1, 1, 1, 2))
+    }
+
+    @Test
+    fun `hexDistance ist symmetrisch`() {
+        assertEquals(
+            HexGridLogic.hexDistance(0, 0, 3, 4),
+            HexGridLogic.hexDistance(3, 4, 0, 0)
+        )
+    }
+
+    @Test
+    fun `hexDistance fuer zwei Schritte ist 2`() {
+        assertEquals(2, HexGridLogic.hexDistance(2, 2, 2, 0))
+        assertEquals(2, HexGridLogic.hexDistance(2, 2, 4, 1))
+    }
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogicTest.kt
@@ -1,10 +1,14 @@
 package at.aau.serg.websocketbrokerdemo.ui.game
 
 import androidx.compose.ui.unit.IntSize
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.Move
 import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
+import at.aau.serg.websocketbrokerdemo.grid.HexGridLogic
+import at.aau.serg.websocketbrokerdemo.grid.MapLayout
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -211,5 +215,149 @@ class GameScreenLogicTest {
             placementMode = null
         )
         assertEquals(GameScreenLogic.TapAction.Ignore, action)
+    }
+
+    @Test
+    fun `tapping own BASE returns Ignore, not Select`() {
+        val base = GameUnit(player = alice, x = 4, y = 4, type = UnitType.BASE)
+        val action = GameScreenLogic.decideTapAction(
+            col = 4, row = 4,
+            units = listOf(base),
+            localName = alice,
+            currentlySelected = null,
+            placementMode = null
+        )
+        assertEquals(GameScreenLogic.TapAction.Ignore, action)
+    }
+
+    @Test
+    fun `tapping own BASE with another unit selected stays Ignore`() {
+        val base = GameUnit(player = alice, x = 4, y = 4, type = UnitType.BASE)
+        val selected = ownInf(2, 2)
+        val action = GameScreenLogic.decideTapAction(
+            col = 4, row = 4,
+            units = listOf(base, selected),
+            localName = alice,
+            currentlySelected = selected,
+            placementMode = null
+        )
+        assertEquals(GameScreenLogic.TapAction.Ignore, action)
+    }
+
+    // ---- reachableCells ----------------------------------------------
+
+    private val testLayout = MapLayout(rows = 7, cols = 7, hexSize = 10f, name = "test")
+
+    private fun field(x: Int, y: Int, owner: String?) = Field(x = x, y = y, owner = owner)
+
+    @Test
+    fun `reachableCells leer wenn Einheit bereits gezogen`() {
+        val unit = ownInf(3, 3).copy(hasMovedThisTurn = true)
+        val fields = listOf(field(3, 3, alice))
+        val result = GameScreenLogic.reachableCells(unit, fields, testLayout)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `reachableCells fuer BASE leer (Basis bewegt sich nicht)`() {
+        val baseUnit = GameUnit(player = alice, x = 3, y = 3, type = UnitType.BASE)
+        val fields = listOf(field(3, 3, alice))
+        val result = GameScreenLogic.reachableCells(baseUnit, fields, testLayout)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `reachableCells liefert IMMER die 6 direkten Nachbarn`() {
+        val unit = ownInf(3, 3)
+        // Nichts ist eigen -> dist-2 ausgeschlossen, aber dist-1 muss bleiben
+        val result = GameScreenLogic.reachableCells(unit, emptyList(), testLayout)
+        assertEquals(6, result.size)
+    }
+
+    @Test
+    fun `reachableCells erlaubt dist-1 unabhaengig vom Owner`() {
+        val unit = ownInf(3, 3)
+        val neighborEnemy = 3 to 2 // dist 1 von (3,3)
+        val fields = listOf(field(neighborEnemy.first, neighborEnemy.second, bob))
+        val result = GameScreenLogic.reachableCells(unit, fields, testLayout)
+        assertTrue(result.contains(neighborEnemy))
+    }
+
+    @Test
+    fun `reachableCells erlaubt dist-2 wenn ein Zwischenfeld eigen ist`() {
+        val unit = ownInf(3, 3)
+        // (3,3)->(2,3)->(1,3): (2,3) ist gemeinsamer Nachbar von Source und Target.
+        val stepStone = 2 to 3
+        val target = 1 to 3
+        val fields = listOf(field(stepStone.first, stepStone.second, alice))
+        val result = GameScreenLogic.reachableCells(unit, fields, testLayout)
+        assertTrue(result.contains(target))
+    }
+
+    @Test
+    fun `reachableCells erlaubt dist-2 auf NEUTRALES Ziel ueber eigenes Zwischenfeld`() {
+        val unit = ownInf(3, 3)
+        val stepStone = 2 to 3
+        val neutralTarget = 1 to 3
+        val fields = listOf(
+            field(stepStone.first, stepStone.second, alice),
+            field(neutralTarget.first, neutralTarget.second, null)
+        )
+        val result = GameScreenLogic.reachableCells(unit, fields, testLayout)
+        assertTrue(result.contains(neutralTarget))
+    }
+
+    @Test
+    fun `reachableCells erlaubt dist-2 auf FEINDLICHES Ziel ueber eigenes Zwischenfeld`() {
+        val unit = ownInf(3, 3)
+        val stepStone = 2 to 3
+        val enemyTarget = 1 to 3
+        val fields = listOf(
+            field(stepStone.first, stepStone.second, alice),
+            field(enemyTarget.first, enemyTarget.second, bob)
+        )
+        val result = GameScreenLogic.reachableCells(unit, fields, testLayout)
+        assertTrue(result.contains(enemyTarget))
+    }
+
+    @Test
+    fun `reachableCells verbietet dist-2 wenn KEIN Zwischenfeld eigen ist`() {
+        val unit = ownInf(3, 3)
+        // Niemand ist eigen -> keine 2-Feld-Bewegung
+        val target = 1 to 3
+        val result = GameScreenLogic.reachableCells(unit, emptyList(), testLayout)
+        assertFalse(result.contains(target))
+    }
+
+    @Test
+    fun `reachableCells verbietet dist-2 auf EIGENES Ziel wenn Pfad nicht eigen ist`() {
+        val unit = ownInf(3, 3)
+        // Target ist eigen, aber die Zwischenfelder (3,2) [nur einer hier]
+        // sind nicht eigen -> nicht erreichbar.
+        val target = 3 to 1
+        val fields = listOf(field(target.first, target.second, alice))
+        val result = GameScreenLogic.reachableCells(unit, fields, testLayout)
+        assertFalse(result.contains(target))
+    }
+
+    @Test
+    fun `reachableCells voll umringt von eigenem Gebiet ergibt 18 Felder`() {
+        val unit = ownInf(3, 3)
+        // alle Felder dem Spieler zuordnen -> 6 Nachbarn + 12 dist-2 = 18
+        val fields = HexGridLogic.allCells(testLayout).map { (c, r) -> field(c, r, alice) }.toList()
+        val result = GameScreenLogic.reachableCells(unit, fields, testLayout)
+        assertEquals(18, result.size)
+        assertFalse(result.contains(3 to 3))
+    }
+
+    @Test
+    fun `reachableCells clamped auf Map-Bounds`() {
+        val unit = ownInf(0, 0)
+        val result = GameScreenLogic.reachableCells(unit, emptyList(), testLayout)
+        assertTrue(result.isNotEmpty())
+        result.forEach { (col, row) ->
+            assertTrue(col in 0 until testLayout.cols)
+            assertTrue(row in 0 until testLayout.rows)
+        }
     }
 }


### PR DESCRIPTION
## Zusammenfassung
Beim Antippen einer eigenen Einheit werden alle Felder ausserhalb der Reichweite halbtransparent abgedunkelt, sodass die moeglichen Zugziele klar sichtbar sind.
Reichweite ist pfadbasiert: 1 Feld immer (eigen / neutral / feindlich), 2 Felder nur wenn das Zwischenfeld dem Spieler gehoert ("Marsch uebers eigene Gebiet").
Die Hauptbasis ist nicht mehr selektierbar und zeigt keinen Bewegungsradius mehr.


### Test plan

Eigene Einheit auf eigenem Gebiet auswaehlen -> direkte Nachbarn und alle dist-2-Felder mit eigenem Zwischenfeld bleiben hell, Rest abgedunkelt

Einheit auf neutralem/feindlichem Feld auswaehlen -> nur die 6 direkten Nachbarn hell

Einheit neben eigener Basis: dist-2-Feld auf neutralem/feindlichem Ziel ueber eigenes Zwischenfeld bleibt hell

Eigene Hauptbasis antippen -> keine Markierung, keine Selektion

Einheit die schon gezogen hat -> keine Markierung

Unit-Tests fuer HexGridLogic.hexDistance und GameScreenLogic.reachableCells 