### PR TITLE
Add income detail popup with full breakdown

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/Field.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/Field.kt
@@ -8,10 +8,15 @@ package at.aau.serg.websocketbrokerdemo.data.serverside
  * um eroberte Gebiete in der Spielerfarbe einzufaerben.
  *
  * Felder:
- *  - x      Spalten-Koordinate auf der Hex-Map (siehe Server-Mapgenerator).
- *  - y      Zeilen-Koordinate auf der Hex-Map.
- *  - owner  Name des Spielers, dem das Feld gehoert,
- *           oder null wenn das Feld neutral / unbeansprucht ist.
+ *  - x           Spalten-Koordinate auf der Hex-Map (siehe Server-Mapgenerator).
+ *  - y           Zeilen-Koordinate auf der Hex-Map.
+ *  - owner       Name des Spielers, dem das Feld gehoert,
+ *                oder null wenn das Feld neutral / unbeansprucht ist.
+ *  - isSkeleton  Markiert ein Feld, das vom Hauptgebiet des Spielers
+ *                abgeschnitten ist (vom Server berechnet via
+ *                recomputeConnectivity). Owner bleibt erhalten -- der
+ *                Spieler kann das Feld zurueckerobern -- aber Skelett-
+ *                Felder geben kein Income pro Runde. Default false.
  *
  * Muss mit dem Server-DTO at.aau.hexabrawl.websocketserver.model.Field
  * uebereinstimmen, damit Gson die GameState-Updates korrekt
@@ -20,5 +25,6 @@ package at.aau.serg.websocketbrokerdemo.data.serverside
 data class Field(
     val x: Int = 0,
     val y: Int = 0,
-    var owner: String? = null
+    var owner: String? = null,
+    var isSkeleton: Boolean = false
 )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/Player.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/Player.kt
@@ -14,12 +14,18 @@ package at.aau.serg.websocketbrokerdemo.data.serverside
  *  - color        Spielerfarbe. Wird in der Lobby beim Join gewaehlt
  *                 und ist im Match einzigartig pro Raum.
  *  - gold         Aktueller Gold-Bestand. Wird fuer Kaeufe (Farm, Einheit)
- *                 verbraucht und am Rundenende durch income aufgestockt.
+ *                 verbraucht und am Rundenende durch income aufgestockt
+ *                 sowie um upkeep verringert.
  *  - farms        Anzahl der vom Spieler bereits gekauften Farmen.
  *                 Wird vom Server zur Berechnung des naechsten Farm-Preises
  *                 benutzt: cost = FARM_BASE_COST + farms * FARM_COST_INCREMENT.
- *  - income       Gold-Einkommen pro Runde (steigt mit eroberten Feldern,
- *                 gebauten Farmen, ...).
+ *  - income       Brutto-Gold-Einkommen pro Runde. Server-Truth, gerechnet als
+ *                 farms * FARM_INCOME_PER_ROUND + ownedFields * FIELD_INCOME_PER_ROUND
+ *                 (Skelett-Felder zaehlen nicht).
+ *  - upkeep       Truppenunterhalt pro Runde. Server-Truth, gerechnet als
+ *                 (0 until unitCount).sumOf { 3 + it } -- die erste Kampf-
+ *                 Einheit kostet 3 Gold, jede weitere +1. Reicht das Gold
+ *                 am Rundenende nicht, werden alle Truppen zu Skeletten.
  *  - hasUsedGift  Ob der Spieler die Schummel-Geschenk-Funktion in
  *                 diesem Match bereits einmal benutzt hat. Server-Truth,
  *                 damit der Geschenk-Button im HUD nicht client-side
@@ -32,5 +38,6 @@ data class Player(
     val gold: Int = 0,
     val farms: Int = 0,
     val income: Int = 0,
+    val upkeep: Int = 0,
     val hasUsedGift: Boolean = false
 )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -70,8 +70,8 @@ fun GameScreen(
     }
 
     val units = gameState?.units.orEmpty()
-    val players = gameState?.players.orEmpty()
     val fields = gameState?.fields.orEmpty()
+    val players = gameState?.players.orEmpty()
     val localName = session.localPlayerName.value
     val pendingGift = gameState?.pendingGift
     val currentTurn = gameState?.currentTurn
@@ -119,6 +119,8 @@ fun GameScreen(
 
         TopHud(
             players = players,
+            units = units,
+            fields = fields,
             localName = localName,
             pendingGift = pendingGift,
             session = session,
@@ -127,7 +129,6 @@ fun GameScreen(
 
         BottomHud(
             players = players,
-            buildings = gameState?.buildings.orEmpty(),
             localName = localName,
             currentTurn = currentTurn,
             status = status,

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/BottomHud.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/BottomHud.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import at.aau.serg.websocketbrokerdemo.data.serverside.Building
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
 import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
@@ -46,7 +45,6 @@ import at.aau.serg.websocketbrokerdemo.ui.theme.WoodMedium
 @Composable
 fun BottomHud(
     players: List<Player>,
-    buildings: List<Building>,
     localName: String?,
     currentTurn: String?,
     status: GameStatus,
@@ -59,7 +57,7 @@ fun BottomHud(
     val gold = BottomHudLogic.goldOf(players, localName)
     val playerColor = BottomHudLogic.colorOf(players, localName)
     val isMyTurn = BottomHudLogic.isMyTurn(currentTurn, status, localName)
-    val farmPrice = BottomHudLogic.farmPrice(buildings, localName)
+    val farmPrice = BottomHudLogic.farmPrice(players, localName)
 
     Box(
         modifier = modifier
@@ -103,7 +101,7 @@ fun BottomHud(
                 .padding(horizontal = 10.dp)
         ) {
             FarmButton(
-                enabled = BottomHudLogic.canBuyFarm(gold, isMyTurn, buildings, localName),
+                enabled = BottomHudLogic.canBuyFarm(gold, isMyTurn, players, localName),
                 price = farmPrice,
                 onClick = onBuyFarm
             )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/BottomHudLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/BottomHudLogic.kt
@@ -1,7 +1,5 @@
 package at.aau.serg.websocketbrokerdemo.ui.game.bottomhud
 
-import at.aau.serg.websocketbrokerdemo.data.serverside.Building
-import at.aau.serg.websocketbrokerdemo.data.serverside.BuildingType
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
 import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
@@ -42,22 +40,28 @@ object BottomHudLogic {
                 currentTurn != null &&
                 currentTurn == localName
 
-    /** Anzahl der Farms des lokalen Spielers. */
-    fun farmCountOf(buildings: List<Building>, localName: String?): Int {
+    /**
+     * Anzahl der Farms des lokalen Spielers (Server-Truth via Player.farms).
+     *
+     * Wichtig: vorher zaehlte diese Funktion Buildings -- aber der Server
+     * inkrementiert beim Farm-Kauf nur Player.farms und legt keinen
+     * Building-Eintrag an. Player.farms ist die einzig korrekte Quelle.
+     */
+    fun farmCountOf(players: List<Player>, localName: String?): Int {
         if (localName == null) return 0
-        return buildings.count { it.player == localName && it.type == BuildingType.FARM }
+        return players.firstOrNull { it.name == localName }?.farms ?: 0
     }
 
     /** Dynamischer Farm-Preis: erste kostet 10, jede weitere +1. */
-    fun farmPrice(buildings: List<Building>, localName: String?): Int {
-        val count = farmCountOf(buildings, localName)
+    fun farmPrice(players: List<Player>, localName: String?): Int {
+        val count = farmCountOf(players, localName)
         return 10 + count
     }
 
     /** Darf ich eine Farm kaufen? (mit dynamischem Preis) */
-    fun canBuyFarm(gold: Int, isMyTurn: Boolean, buildings: List<Building>, localName: String?): Boolean {
+    fun canBuyFarm(gold: Int, isMyTurn: Boolean, players: List<Player>, localName: String?): Boolean {
         if (!isMyTurn) return false
-        return gold >= farmPrice(buildings, localName)
+        return gold >= farmPrice(players, localName)
     }
 
     /** Darf ich gerade diese Einheit kaufen? */

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/HudPopup.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/HudPopup.kt
@@ -1,0 +1,21 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud
+
+/**
+ * Welches Popup ueber dem Top-HUD gerade sichtbar ist.
+ */
+enum class HudPopup {
+    /** Kein Popup offen. */
+    None,
+
+    /** Menue-Popup mit Settings/Info-Auswahl. */
+    Menu,
+
+    /** Info-Popup mit Spielerklaerung inkl. Schummel-Hinweis. */
+    Info,
+
+    /** In-Game-Einstellungen (nur Audio, ohne Sprache). */
+    Settings,
+
+    /** Einkommen-Detail-Popup mit Aufschluesselung pro Runde. */
+    Income
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/IncomeBreakdown.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/IncomeBreakdown.kt
@@ -1,0 +1,50 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud
+
+/**
+ * View-State fuers Einkommen-Detail-Popup.
+ *
+ * Wird von [IncomeBreakdownLogic] aus dem Server-GameState abgeleitet
+ * und vom [components.IncomeDetailsPopup] angezeigt. Reine Datenklasse
+ * ohne Compose-Abhaengigkeit -- damit ist die Berechnung in
+ * [IncomeBreakdownLogic] ohne Compose-Runtime testbar.
+ *
+ * Aufbau spiegelt den Server (siehe GameService.computeIncome /
+ * computeUpkeep):
+ *  - Brutto = farms * goldPerFarm + fields * goldPerField
+ *  - Upkeep = (0 until units).sumOf { 3 + it }   -> (3+4+5+...)
+ *  - Netto  = Brutto - Upkeep
+ *
+ * Felder:
+ *  - farms         Anzahl Farmen des lokalen Spielers (Server-Truth).
+ *  - goldPerFarm   Gold pro Farm pro Runde (Konstante, spiegelt
+ *                  FARM_INCOME_PER_ROUND im Server).
+ *  - farmIncome    Brutto-Einkommen aus Farmen: farms * goldPerFarm.
+ *  - fields        Anzahl Income-gebender Felder des Spielers.
+ *                  Skelett-Felder gehoeren ihm noch, geben aber kein
+ *                  Gold und zaehlen hier nicht.
+ *  - goldPerField  Gold pro Feld pro Runde (Konstante, spiegelt
+ *                  FIELD_INCOME_PER_ROUND im Server).
+ *  - fieldIncome   Brutto-Einkommen aus Feldern: fields * goldPerField.
+ *  - grossIncome   Brutto-Einkommen total = farmIncome + fieldIncome.
+ *                  Sollte mit Player.income vom Server uebereinstimmen
+ *                  -- Konsistenz-Pruefung im Test.
+ *  - units         Anzahl Kampf-Einheiten (ohne BASE und SKELETON),
+ *                  fuer die Unterhalt anfaellt.
+ *  - upkeep        Truppenunterhalt pro Runde, Server-Truth via
+ *                  Player.upkeep.
+ *  - netIncome     Netto pro Runde = grossIncome - upkeep. Negative
+ *                  Werte deuten auf drohende Insolvenz hin (alle
+ *                  Truppen werden zu Skeletten).
+ */
+data class IncomeBreakdown(
+    val farms: Int = 0,
+    val goldPerFarm: Int = 0,
+    val farmIncome: Int = 0,
+    val fields: Int = 0,
+    val goldPerField: Int = 0,
+    val fieldIncome: Int = 0,
+    val grossIncome: Int = 0,
+    val units: Int = 0,
+    val upkeep: Int = 0,
+    val netIncome: Int = 0
+)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/IncomeBreakdownLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/IncomeBreakdownLogic.kt
@@ -1,0 +1,76 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
+import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
+
+/**
+ * Pure Logik fuers Income-Detail-Popup.
+ *
+ * Baut aus dem Server-State den View-State [IncomeBreakdown] fuer den
+ * lokalen Spieler. Seiteneffekt-frei und ohne Compose-Runtime, damit
+ * die Berechnung ohne Composable-Setup testbar ist.
+ *
+ * Source-of-Truth-Aufteilung:
+ *  - grossIncome und upkeep kommen DIREKT vom Server (Player.income
+ *    bzw. Player.upkeep) -- da gibt es keine Doppel-Rechnung.
+ *  - farmIncome und fieldIncome werden client-side fuer die Anzeige
+ *    aufgeschluesselt (das Popup zeigt "Farms 2 x 3 Gold = +6").
+ *  - Drift-Test (siehe IncomeBreakdownLogicTest) prueft, dass
+ *    farmIncome + fieldIncome == player.income gilt -- falls die
+ *    Backend-Konstante sich aendert, schlaegt der Test sofort an.
+ *
+ * Regeln spiegeln den Server (siehe GameService.computeIncome /
+ * computeUpkeep):
+ *  - Felder mit `isSkeleton = true` zaehlen NICHT zum Einkommen
+ *    (gehoeren dem Spieler weiter, geben aber kein Gold).
+ *  - Truppen-Unterhalt wird nur fuer Kampf-Einheiten gezahlt --
+ *    BASE und SKELETON sind ausgenommen.
+ */
+object IncomeBreakdownLogic {
+
+    /**
+     * Liefert den View-State fuers Income-Popup.
+     *
+     * Bei unbekanntem [localName] (z.B. Spieler noch nicht im Raum)
+     * wird ein leerer Breakdown mit Nullwerten und den Spielregel-
+     * Konstanten zurueckgegeben -- das Popup soll sich nicht
+     * weigern zu rendern.
+     */
+    fun buildBreakdown(
+        players: List<Player>,
+        units: List<GameUnit>,
+        fields: List<Field>,
+        localName: String?
+    ): IncomeBreakdown {
+        val player = players.firstOrNull { it.name == localName }
+            ?: return IncomeBreakdown(
+                goldPerFarm = TopHudLogic.GOLD_PER_FARM,
+                goldPerField = TopHudLogic.GOLD_PER_FIELD
+            )
+
+        val fieldCount = fields.count { it.owner == localName && !it.isSkeleton }
+        val unitCount = units.count {
+            it.player == localName &&
+                it.type != UnitType.SKELETON &&
+                it.type != UnitType.BASE
+        }
+
+        val farmIncome = player.farms * TopHudLogic.GOLD_PER_FARM
+        val fieldIncome = fieldCount * TopHudLogic.GOLD_PER_FIELD
+
+        return IncomeBreakdown(
+            farms = player.farms,
+            goldPerFarm = TopHudLogic.GOLD_PER_FARM,
+            farmIncome = farmIncome,
+            fields = fieldCount,
+            goldPerField = TopHudLogic.GOLD_PER_FIELD,
+            fieldIncome = fieldIncome,
+            grossIncome = player.income,
+            units = unitCount,
+            upkeep = player.upkeep,
+            netIncome = player.income - player.upkeep
+        )
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHud.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHud.kt
@@ -14,6 +14,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.PendingGift
 import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.network.GameSession
@@ -22,6 +24,7 @@ import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.HudMenuButton
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.HudMenuPopup
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.InGameSettingsPopup
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.IncomeAndGiftDisplay
+import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.IncomeDetailsPopup
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.InfoPopup
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.StealPopup
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.WaitingForOpponentOverlay
@@ -30,7 +33,7 @@ import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.WaitingForOppon
  * Top-HUD des GameScreens.
  *
  * Drei freischwebende Boxen am oberen Bildschirmrand plus die Popups
- * fuer Menue/Info/Settings/Steal/Waiting.
+ * fuer Menue/Info/Settings/Income/Steal/Waiting.
  *
  * Der Schummel-Geschenk-Flow:
  *  - Klick aufs Geschenk-Icon laeuft ueber [CheatGiftViewModel]
@@ -41,10 +44,18 @@ import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.WaitingForOppon
  *  - Sobald pendingGift weg ist, wird der lokale "schon entschieden"-
  *    State zurueckgesetzt fuer ein eventuelles naechstes Geschenk
  *    eines anderen Spielers.
+ *
+ * Der Einkommen-Detail-Flow:
+ *  - Klick auf die Einkommen-Box oeffnet das [IncomeDetailsPopup]
+ *  - View-State wird live aus [players], [units] und [fields] gebaut,
+ *    damit Server-Updates (Feld erobert, Truppe verloren) direkt im
+ *    offenen Popup sichtbar sind.
  */
 @Composable
 fun TopHud(
     players: List<Player>,
+    units: List<GameUnit>,
+    fields: List<Field>,
     localName: String?,
     pendingGift: PendingGift?,
     session: GameSession,
@@ -60,10 +71,9 @@ fun TopHud(
     val cheatState by cheatViewModel.state.collectAsStateWithLifecycle()
 
     val gold = TopHudLogic.goldFor(players, localName)
-    val income = TopHudLogic.incomeFor(players, localName)
+    val income = TopHudLogic.netIncomeFor(players, localName)
     val giftEnabled = CheatGiftLogic.canUseGift(players, localName)
 
-    // Bei aufgeloestem pendingGift den hasResponded-Flag zuruecksetzen.
     LaunchedEffect(pendingGift) {
         if (pendingGift == null) {
             cheatViewModel.onPendingGiftCleared()
@@ -83,6 +93,7 @@ fun TopHud(
         IncomeAndGiftDisplay(
             income = income,
             giftEnabled = giftEnabled,
+            onIncomeClick = viewModel::showIncome,
             onGiftClick = { localName?.let { cheatViewModel.onGiftClick(it) } }
         )
 
@@ -91,7 +102,6 @@ fun TopHud(
         HudMenuButton(onClick = viewModel::openMenu)
     }
 
-    // Settings-/Menue-/Info-Popups
     when (state.popup) {
         HudPopup.None -> Unit
         HudPopup.Menu -> HudMenuPopup(
@@ -101,9 +111,12 @@ fun TopHud(
         )
         HudPopup.Info -> InfoPopup(onDismiss = viewModel::closePopup)
         HudPopup.Settings -> InGameSettingsPopup(onDismiss = viewModel::closePopup)
+        HudPopup.Income -> IncomeDetailsPopup(
+            breakdown = IncomeBreakdownLogic.buildBreakdown(players, units, fields, localName),
+            onDismiss = viewModel::closePopup
+        )
     }
 
-    // Schummel-Geschenk-Popups
     if (pendingGift != null) {
         when {
             CheatGiftLogic.shouldShowWaitingOverlay(pendingGift, localName) -> {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudLogic.kt
@@ -10,11 +10,36 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.Player
  */
 object TopHudLogic {
 
+    /**
+     * Gold pro Farm pro Runde -- spiegelt FARM_INCOME_PER_ROUND im
+     * Server (siehe GameService.kt). Wird vom Income-Detail-Popup
+     * angezeigt; bei Aenderung im Backend hier nachziehen.
+     */
+    const val GOLD_PER_FARM = 3
+
+    /**
+     * Gold pro besessenem Feld pro Runde -- spiegelt FIELD_INCOME_PER_ROUND
+     * im Server (siehe GameService.kt). Skelett-Felder zaehlen nicht.
+     * Wird vom Income-Detail-Popup angezeigt; bei Aenderung im Backend
+     * hier nachziehen.
+     */
+    const val GOLD_PER_FIELD = 1
+
     /** Gold-Bestand des lokalen Spielers, 0 wenn nicht gefunden. */
     fun goldFor(players: List<Player>, localName: String?): Int =
         players.firstOrNull { it.name == localName }?.gold ?: 0
 
-    /** Einkommen des lokalen Spielers pro Runde, 0 wenn nicht gefunden. */
+    /** Brutto-Einkommen des lokalen Spielers pro Runde, 0 wenn nicht gefunden. */
     fun incomeFor(players: List<Player>, localName: String?): Int =
         players.firstOrNull { it.name == localName }?.income ?: 0
+
+    /**
+     * Netto-Einkommen des lokalen Spielers pro Runde (income - upkeep).
+     * Spiegelt den tatsaechlichen Gold-Zuwachs am Rundenende. Negativ
+     * heisst Insolvenz -- alle Truppen werden zu Skeletten.
+     */
+    fun netIncomeFor(players: List<Player>, localName: String?): Int {
+        val player = players.firstOrNull { it.name == localName } ?: return 0
+        return player.income - player.upkeep
+    }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudState.kt
@@ -1,23 +1,6 @@
 package at.aau.serg.websocketbrokerdemo.ui.game.tophud
 
 /**
- * Welches Popup ueber dem Top-HUD gerade sichtbar ist.
- */
-enum class HudPopup {
-    /** Kein Popup offen. */
-    None,
-
-    /** Menue-Popup mit Settings/Info-Auswahl. */
-    Menu,
-
-    /** Info-Popup mit Spielerklaerung inkl. Schummel-Hinweis. */
-    Info,
-
-    /** In-Game-Einstellungen (nur Audio, ohne Sprache). */
-    Settings
-}
-
-/**
  * UI-State des Top-HUDs.
  *
  * Verwaltet die Sichtbarkeit der Popups. Die Spielzustands-Daten

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudViewModel.kt
@@ -32,6 +32,14 @@ class TopHudViewModel : ViewModel() {
         _state.value = TopHudState(popup = HudPopup.Settings)
     }
 
+    /**
+     * Oeffnet das Einkommen-Detail-Popup. Wird durch Klick auf die
+     * Einkommen-Box im Top-HUD ausgeloest.
+     */
+    fun showIncome() {
+        _state.value = TopHudState(popup = HudPopup.Income)
+    }
+
     /** Schliesst alle Popups. */
     fun closePopup() {
         _state.value = TopHudState(popup = HudPopup.None)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeAndGiftDisplay.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeAndGiftDisplay.kt
@@ -33,16 +33,20 @@ import com.example.myapplication.R
 /**
  * Mittlere HUD-Box: Einkommen pro Runde + Geschenk-Button.
  *
- *  - [income]        Goldeinkommen pro Runde
- *  - [giftEnabled]   false = Spieler hat sein Geschenk bereits benutzt
- *                    (Server-Truth via Player.hasUsedGift); das Icon
- *                    wird dann grayed out und nicht mehr klickbar.
- *  - [onGiftClick]   Wird beim 5. Klick zum Auswerfen verwendet.
+ *  - [income]         Goldeinkommen pro Runde.
+ *  - [giftEnabled]    false = Spieler hat sein Geschenk bereits benutzt
+ *                     (Server-Truth via Player.hasUsedGift); das Icon
+ *                     wird dann grayed out und nicht mehr klickbar.
+ *  - [onIncomeClick]  Wird ausgeloest, wenn der Spieler auf die
+ *                     "+X /Runde" Box tippt. Oeffnet das Income-Detail-
+ *                     Popup mit der Aufschluesselung.
+ *  - [onGiftClick]    Wird beim 5. Klick zum Auswerfen verwendet.
  */
 @Composable
 fun IncomeAndGiftDisplay(
     income: Int,
     giftEnabled: Boolean,
+    onIncomeClick: () -> Unit,
     onGiftClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -57,23 +61,28 @@ fun IncomeAndGiftDisplay(
             .border(2.dp, GoldCoinDark, RoundedCornerShape(10.dp))
             .padding(horizontal = 12.dp, vertical = 4.dp)
     ) {
-        Text(
-            text = "+$income",
-            style = TextStyle(
-                fontSize = 22.sp,
-                fontWeight = FontWeight.ExtraBold,
-                color = Color(0xFF2D7A1F)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.clickable(onClick = onIncomeClick)
+        ) {
+            Text(
+                text = if (income >= 0) "+$income" else "$income",
+                style = TextStyle(
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = if (income >= 0) Color(0xFF2D7A1F) else Color(0xFFB22222)
+                )
             )
-        )
-        Spacer(Modifier.width(4.dp))
-        Text(
-            text = stringResource(R.string.hud_per_round),
-            style = TextStyle(
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Bold,
-                color = InkBlack
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = stringResource(R.string.hud_per_round),
+                style = TextStyle(
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = InkBlack
+                )
             )
-        )
+        }
         Spacer(Modifier.width(10.dp))
 
         val giftModifier = Modifier

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeDetailsPopup.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeDetailsPopup.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -88,7 +88,7 @@ fun IncomeDetailsPopup(
             )
 
             Spacer(Modifier.height(8.dp))
-            Divider(color = GoldCoinDark, thickness = 1.dp)
+            HorizontalDivider(thickness = 1.dp, color = GoldCoinDark)
             Spacer(Modifier.height(8.dp))
 
             IncomeRow(
@@ -98,7 +98,7 @@ fun IncomeDetailsPopup(
             )
 
             Spacer(Modifier.height(8.dp))
-            Divider(color = GoldCoinDark, thickness = 1.dp)
+            HorizontalDivider(thickness = 1.dp, color = GoldCoinDark)
             Spacer(Modifier.height(8.dp))
 
             IncomeSectionHeader(label = stringResource(R.string.income_upkeep))
@@ -111,7 +111,7 @@ fun IncomeDetailsPopup(
             )
 
             Spacer(Modifier.height(8.dp))
-            Divider(color = GoldCoinDark, thickness = 1.dp)
+            HorizontalDivider(thickness = 1.dp, color = GoldCoinDark)
             Spacer(Modifier.height(8.dp))
 
             IncomeRow(

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeDetailsPopup.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeDetailsPopup.kt
@@ -1,0 +1,162 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import at.aau.serg.websocketbrokerdemo.ui.game.tophud.IncomeBreakdown
+import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinDark
+import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
+import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentDark
+import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentLight
+import com.example.myapplication.R
+
+/**
+ * Detail-Popup fuers Einkommen pro Runde.
+ *
+ * Reine Anzeige-Komponente. Bekommt den View-State [IncomeBreakdown]
+ * von oben (gebaut in [at.aau.serg.websocketbrokerdemo.ui.game.tophud
+ * .IncomeBreakdownLogic.buildBreakdown]) und ruft [onDismiss] beim
+ * Schliessen auf. Keine Berechnung, kein Server-Zugriff.
+ *
+ * Aufbau (wie im Mockup): Drei Aufschluesselungs-Bloecke (Farmen,
+ * Felder, Truppenunterhalt) jeweils mit Header-Zeile (Kategorie-Name)
+ * und Body-Zeile (Formel + Wert). Dazwischen die Summen-Zeilen
+ * "Einkommen brutto" und "Netto pro Runde" als fette Einzeiler.
+ */
+@Composable
+fun IncomeDetailsPopup(
+    breakdown: IncomeBreakdown,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .shadow(20.dp, RoundedCornerShape(16.dp))
+                .background(
+                    brush = Brush.verticalGradient(listOf(ParchmentLight, ParchmentDark)),
+                    shape = RoundedCornerShape(16.dp)
+                )
+                .border(3.dp, GoldCoinDark, RoundedCornerShape(16.dp))
+                .padding(24.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.income_dialog_title),
+                style = TextStyle(
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = InkBlack,
+                    letterSpacing = 1.5.sp
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            IncomeSectionHeader(label = stringResource(R.string.income_farms))
+            IncomeRow(
+                label = "${breakdown.farms} x ${breakdown.goldPerFarm} ${stringResource(R.string.income_gold)}",
+                value = "= +${breakdown.farmIncome}",
+                modifier = Modifier.padding(start = 12.dp)
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            IncomeSectionHeader(label = stringResource(R.string.income_fields))
+            IncomeRow(
+                label = "${breakdown.fields} x ${breakdown.goldPerField} ${stringResource(R.string.income_gold)}",
+                value = "= +${breakdown.fieldIncome}",
+                modifier = Modifier.padding(start = 12.dp)
+            )
+
+            Spacer(Modifier.height(8.dp))
+            Divider(color = GoldCoinDark, thickness = 1.dp)
+            Spacer(Modifier.height(8.dp))
+
+            IncomeRow(
+                label = stringResource(R.string.income_gross),
+                value = "+${breakdown.grossIncome}",
+                bold = true
+            )
+
+            Spacer(Modifier.height(8.dp))
+            Divider(color = GoldCoinDark, thickness = 1.dp)
+            Spacer(Modifier.height(8.dp))
+
+            IncomeSectionHeader(label = stringResource(R.string.income_upkeep))
+            val upkeepFormula = upkeepFormulaString(breakdown.units)
+            val troopsLabel = stringResource(R.string.income_troops_with_count, breakdown.units)
+            IncomeRow(
+                label = "$troopsLabel $upkeepFormula".trim(),
+                value = "-${breakdown.upkeep}",
+                modifier = Modifier.padding(start = 12.dp)
+            )
+
+            Spacer(Modifier.height(8.dp))
+            Divider(color = GoldCoinDark, thickness = 1.dp)
+            Spacer(Modifier.height(8.dp))
+
+            IncomeRow(
+                label = stringResource(R.string.income_net),
+                value = formatSigned(breakdown.netIncome),
+                bold = true
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            Button(
+                onClick = onDismiss,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = GoldCoinDark,
+                    contentColor = InkBlack
+                ),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = stringResource(R.string.dialog_close),
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Baut den Anzeige-String fuer die Truppenunterhalt-Formel.
+ * Beispiel: bei units=3 -> "(3+4+5)", bei units=1 -> "(3)",
+ * bei units=0 -> "" (keine Klammer).
+ */
+private fun upkeepFormulaString(units: Int): String {
+    if (units <= 0) return ""
+    val terms = (0 until units).map { 3 + it }
+    return "(${terms.joinToString("+")})"
+}
+
+/**
+ * Formatiert eine Zahl mit Vorzeichen: 5 -> "+5", -2 -> "-2", 0 -> "0".
+ */
+private fun formatSigned(value: Int): String = when {
+    value > 0 -> "+$value"
+    else -> "$value"
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeRow.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeRow.kt
@@ -1,0 +1,60 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
+
+/**
+ * Eine Zeile im Einkommen-Detail-Popup.
+ *
+ * Label links, Wert rechts -- konsistent gestaltet, damit alle
+ * Zeilen (Farmen, Felder, Brutto, Truppenunterhalt, Netto) gleich
+ * aussehen.
+ *
+ *  - [label]  Klartext links, z.B. "Farmen" oder "Einkommen brutto".
+ *  - [value]  Anzuzeigender Wert rechts, z.B. "+6" oder "-12".
+ *  - [bold]   Wenn true wird die Zeile extrabold gerendert -- gedacht
+ *             fuer Summen-Zeilen wie "Einkommen brutto" und "Netto".
+ */
+@Composable
+fun IncomeRow(
+    label: String,
+    value: String,
+    bold: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = TextStyle(
+                fontSize = 14.sp,
+                fontWeight = if (bold) FontWeight.ExtraBold else FontWeight.Medium,
+                color = InkBlack
+            )
+        )
+        Text(
+            text = value,
+            style = TextStyle(
+                fontSize = 14.sp,
+                fontWeight = if (bold) FontWeight.ExtraBold else FontWeight.Bold,
+                color = InkBlack
+            )
+        )
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeSectionHeader.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/IncomeSectionHeader.kt
@@ -1,0 +1,35 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
+
+/**
+ * Kleiner Header oberhalb einer Aufschluesselungs-Zeile im
+ * Einkommen-Detail-Popup -- nur die Kategorie ("Farmen", "Felder",
+ * "Truppenunterhalt") ohne Wert. Wird vom [IncomeDetailsPopup]
+ * dreimal verwendet, damit die Bloecke visuell konsistent wirken.
+ *
+ *  - [label]  Kategorie-Name als Klartext.
+ */
+@Composable
+fun IncomeSectionHeader(label: String) {
+    Text(
+        text = label,
+        style = TextStyle(
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = InkBlack
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp)
+    )
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -80,6 +80,16 @@
     <string name="hud_info_cheat_body">Wenn du oft auf das Geschenk-Symbol drückst, kannst du Gold gewinnen oder verlieren. Aber pass auf: dein Gegner sieht es und kann versuchen dein Geschenk zu stehlen!</string>
     <string name="dialog_close">Schließen</string>
 
+    <!--suppress PluralsCandidate -->
+    <string name="income_dialog_title">Einkommen pro Runde</string>
+    <string name="income_farms">Farmen</string>
+    <string name="income_fields">Felder</string>
+    <string name="income_gold">Gold</string>
+    <string name="income_gross">Einkommen brutto</string>
+    <string name="income_troops_with_count">%d Truppen</string>
+    <string name="income_upkeep">Truppenunterhalt</string>
+    <string name="income_net">Netto pro Runde</string>
+
     <!-- DE (values-de/strings.xml) -->
     <string name="cheat_steal_title">Ein Geschenk!</string>
     <string name="cheat_steal_body">%1$s hat ein verdaechtiges Geschenk geoeffnet. Willst du es stehlen? Du weisst nicht ob du Gold gewinnst oder verlierst — riskiere es!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,16 @@
     <string name="hud_info_cheat_body">If you tap the gift icon multiple times, you may win or lose gold. But careful: your opponent can see it and might try to steal your gift!</string>
     <string name="dialog_close">Close</string>
 
+    <!--suppress PluralsCandidate -->
+    <string name="income_dialog_title">Income per round</string>
+    <string name="income_farms">Farms</string>
+    <string name="income_fields">Fields</string>
+    <string name="income_gold">Gold</string>
+    <string name="income_gross">Gross income</string>
+    <string name="income_troops_with_count">%d troops</string>
+    <string name="income_upkeep">Troop upkeep</string>
+    <string name="income_net">Net per round</string>
+
     <!-- EN (values/strings.xml) -->
     <string name="cheat_steal_title">A gift!</string>
     <string name="cheat_steal_body">%1$s opened a suspicious gift. Want to steal it? You don\'t know if you\'ll win or lose gold — risk it!</string>

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/BottomHudLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/BottomHudLogicTest.kt
@@ -1,7 +1,5 @@
 package at.aau.serg.websocketbrokerdemo.ui.game.bottomhud
 
-import at.aau.serg.websocketbrokerdemo.data.serverside.Building
-import at.aau.serg.websocketbrokerdemo.data.serverside.BuildingType
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
 import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
@@ -102,32 +100,27 @@ class BottomHudLogicTest {
     // ---- farmCountOf ---------------------------------------------------
 
     @Test
-    fun `farmCountOf returns 0 when player has no buildings`() {
-        val buildings = emptyList<Building>()
-        val result = BottomHudLogic.farmCountOf(buildings, "A")
+    fun `farmCountOf returns 0 when player has no farms`() {
+        val players = listOf(Player(name = "A", farms = 0))
+        val result = BottomHudLogic.farmCountOf(players, "A")
         assertEquals(0, result)
     }
 
     @Test
-    fun `farmCountOf counts only farms of the local player`() {
-        val buildings = listOf(
-            Building(player = "A", type = BuildingType.FARM),
-            Building(player = "A", type = BuildingType.FARM),
-            Building(player = "B", type = BuildingType.FARM),   // anderer Spieler
-            Building(player = "A", type = BuildingType.CASTLE)  // kein Farm
+    fun `farmCountOf returns the farm count of the local player`() {
+        val players = listOf(
+            Player(name = "A", farms = 2),
+            Player(name = "B", farms = 5)
         )
 
-        val result = BottomHudLogic.farmCountOf(buildings, "A")
+        val result = BottomHudLogic.farmCountOf(players, "A")
         assertEquals(2, result)
     }
 
     @Test
     fun `farmCountOf returns 0 when localName is null`() {
-        val buildings = listOf(
-            Building(player = "A", type = BuildingType.FARM)
-        )
-
-        val result = BottomHudLogic.farmCountOf(buildings, null)
+        val players = listOf(Player(name = "A", farms = 3))
+        val result = BottomHudLogic.farmCountOf(players, null)
         assertEquals(0, result)
     }
 
@@ -135,31 +128,27 @@ class BottomHudLogicTest {
 
     @Test
     fun `farmPrice is 10 when player owns no farms`() {
-        val buildings = emptyList<Building>()
-        val result = BottomHudLogic.farmPrice(buildings, "A")
+        val players = listOf(Player(name = "A", farms = 0))
+        val result = BottomHudLogic.farmPrice(players, "A")
         assertEquals(10, result)
     }
 
     @Test
     fun `farmPrice increases by 1 for each owned farm`() {
-        val buildings = listOf(
-            Building(player = "A", type = BuildingType.FARM),
-            Building(player = "A", type = BuildingType.FARM),
-            Building(player = "A", type = BuildingType.FARM)
-        )
+        val players = listOf(Player(name = "A", farms = 3))
         // 3 Farms → Preis = 10 + 3 = 13
-        val result = BottomHudLogic.farmPrice(buildings, "A")
+        val result = BottomHudLogic.farmPrice(players, "A")
         assertEquals(13, result)
     }
 
     @Test
     fun `farmPrice ignores farms of other players`() {
-        val buildings = listOf(
-            Building(player = "B", type = BuildingType.FARM),
-            Building(player = "B", type = BuildingType.FARM)
+        val players = listOf(
+            Player(name = "A", farms = 0),
+            Player(name = "B", farms = 2)
         )
         // Spieler A hat 0 Farms → Preis = 10
-        val result = BottomHudLogic.farmPrice(buildings, "A")
+        val result = BottomHudLogic.farmPrice(players, "A")
         assertEquals(10, result)
     }
 
@@ -169,12 +158,12 @@ class BottomHudLogicTest {
 
     @Test
     fun `canBuyFarm is true when affordable and my turn`() {
-        val buildings = emptyList<Building>() // 0 Farms → Preis = 10
+        val players = listOf(Player(name = "A", farms = 0)) // Preis = 10
         assertTrue(
             BottomHudLogic.canBuyFarm(
                 gold = 100,
                 isMyTurn = true,
-                buildings = buildings,
+                players = players,
                 localName = "A"
             )
         )
@@ -182,12 +171,12 @@ class BottomHudLogicTest {
 
     @Test
     fun `canBuyFarm is false when not enough gold`() {
-        val buildings = emptyList<Building>() // Preis = 10
+        val players = listOf(Player(name = "A", farms = 0)) // Preis = 10
         assertFalse(
             BottomHudLogic.canBuyFarm(
                 gold = 9,
                 isMyTurn = true,
-                buildings = buildings,
+                players = players,
                 localName = "A"
             )
         )
@@ -195,12 +184,12 @@ class BottomHudLogicTest {
 
     @Test
     fun `canBuyFarm is false when not my turn`() {
-        val buildings = emptyList<Building>()
+        val players = listOf(Player(name = "A", farms = 0))
         assertFalse(
             BottomHudLogic.canBuyFarm(
                 gold = 100,
                 isMyTurn = false,
-                buildings = buildings,
+                players = players,
                 localName = "A"
             )
         )
@@ -208,12 +197,12 @@ class BottomHudLogicTest {
 
     @Test
     fun `canBuyFarm is true exactly at price boundary`() {
-        val buildings = emptyList<Building>() // Preis = 10
+        val players = listOf(Player(name = "A", farms = 0)) // Preis = 10
         assertTrue(
             BottomHudLogic.canBuyFarm(
                 gold = 10,
                 isMyTurn = true,
-                buildings = buildings,
+                players = players,
                 localName = "A"
             )
         )
@@ -221,16 +210,13 @@ class BottomHudLogicTest {
 
     @Test
     fun `canBuyFarm increases price with number of owned farms`() {
-        val buildings = listOf(
-            Building(player = "A", type = BuildingType.FARM),
-            Building(player = "A", type = BuildingType.FARM)
-        )
+        val players = listOf(Player(name = "A", farms = 2))
         // 2 Farms → Preis = 10 + 2 = 12
         assertTrue(
             BottomHudLogic.canBuyFarm(
                 gold = 12,
                 isMyTurn = true,
-                buildings = buildings,
+                players = players,
                 localName = "A"
             )
         )
@@ -238,16 +224,13 @@ class BottomHudLogicTest {
 
     @Test
     fun `canBuyFarm is false when gold is below dynamic price`() {
-        val buildings = listOf(
-            Building(player = "A", type = BuildingType.FARM),
-            Building(player = "A", type = BuildingType.FARM)
-        )
+        val players = listOf(Player(name = "A", farms = 2))
         // Preis = 12, Gold = 11 → false
         assertFalse(
             BottomHudLogic.canBuyFarm(
                 gold = 11,
                 isMyTurn = true,
-                buildings = buildings,
+                players = players,
                 localName = "A"
             )
         )

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/IncomeBreakdownLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/IncomeBreakdownLogicTest.kt
@@ -1,0 +1,169 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.Field
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
+import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests fuer IncomeBreakdownLogic.
+ *
+ * Pure JVM-Unit-Tests ohne Compose-Runtime -- der Punkt der Logic-
+ * Schicht ist genau das, sie ohne UI-Setup pruefen zu koennen.
+ *
+ * Wichtigster Test ist `farmIncome plus fieldIncome equals player income`:
+ * der Drift-Detektor zwischen Client-Konstanten und Server-Backend.
+ */
+class IncomeBreakdownLogicTest {
+
+    private val alice = Player(name = "Alice", farms = 2, income = 10, upkeep = 12)
+    private val bob = Player(name = "Bob", farms = 0, income = 0, upkeep = 0)
+
+    private val aliceFields = listOf(
+        Field(x = 0, y = 0, owner = "Alice"),
+        Field(x = 1, y = 0, owner = "Alice"),
+        Field(x = 2, y = 0, owner = "Alice"),
+        Field(x = 3, y = 0, owner = "Alice")
+    )
+
+    private val aliceUnits = listOf(
+        GameUnit(player = "Alice", type = UnitType.INFANTRY),
+        GameUnit(player = "Alice", type = UnitType.ARCHER),
+        GameUnit(player = "Alice", type = UnitType.CAVALRY)
+    )
+
+    @Test
+    fun `buildBreakdown returns server values for the local player`() {
+        val result = IncomeBreakdownLogic.buildBreakdown(
+            players = listOf(alice, bob),
+            units = aliceUnits,
+            fields = aliceFields,
+            localName = "Alice"
+        )
+
+        assertEquals(2, result.farms)
+        assertEquals(6, result.farmIncome)
+        assertEquals(4, result.fields)
+        assertEquals(4, result.fieldIncome)
+        assertEquals(10, result.grossIncome)
+        assertEquals(3, result.units)
+        assertEquals(12, result.upkeep)
+        assertEquals(-2, result.netIncome)
+    }
+
+    @Test
+    fun `buildBreakdown returns empty values for an empty player list`() {
+        val result = IncomeBreakdownLogic.buildBreakdown(
+            players = emptyList(),
+            units = emptyList(),
+            fields = emptyList(),
+            localName = "Alice"
+        )
+
+        assertEquals(0, result.farms)
+        assertEquals(TopHudLogic.GOLD_PER_FARM, result.goldPerFarm)
+        assertEquals(TopHudLogic.GOLD_PER_FIELD, result.goldPerField)
+        assertEquals(0, result.grossIncome)
+        assertEquals(0, result.upkeep)
+        assertEquals(0, result.netIncome)
+    }
+
+    @Test
+    fun `buildBreakdown returns empty values when localName is not in players`() {
+        val result = IncomeBreakdownLogic.buildBreakdown(
+            players = listOf(alice),
+            units = aliceUnits,
+            fields = aliceFields,
+            localName = "Bob"
+        )
+
+        assertEquals(0, result.farms)
+        assertEquals(0, result.fields)
+        assertEquals(0, result.units)
+        assertEquals(0, result.grossIncome)
+    }
+
+    @Test
+    fun `buildBreakdown returns empty values when localName is null`() {
+        val result = IncomeBreakdownLogic.buildBreakdown(
+            players = listOf(alice),
+            units = aliceUnits,
+            fields = aliceFields,
+            localName = null
+        )
+
+        assertEquals(0, result.farms)
+        assertEquals(0, result.grossIncome)
+    }
+
+    @Test
+    fun `buildBreakdown ignores skeleton fields when counting`() {
+        val mixedFields = listOf(
+            Field(x = 0, y = 0, owner = "Alice"),
+            Field(x = 1, y = 0, owner = "Alice"),
+            Field(x = 2, y = 0, owner = "Alice", isSkeleton = true),
+            Field(x = 3, y = 0, owner = "Alice", isSkeleton = true)
+        )
+        val aliceWithLessIncome = alice.copy(income = 8)
+
+        val result = IncomeBreakdownLogic.buildBreakdown(
+            players = listOf(aliceWithLessIncome),
+            units = emptyList(),
+            fields = mixedFields,
+            localName = "Alice"
+        )
+
+        assertEquals(2, result.fields)
+        assertEquals(2, result.fieldIncome)
+    }
+
+    @Test
+    fun `buildBreakdown ignores skeleton and base units when counting troops`() {
+        val mixedUnits = listOf(
+            GameUnit(player = "Alice", type = UnitType.INFANTRY),
+            GameUnit(player = "Alice", type = UnitType.SKELETON),
+            GameUnit(player = "Alice", type = UnitType.BASE),
+            GameUnit(player = "Bob", type = UnitType.INFANTRY)
+        )
+
+        val result = IncomeBreakdownLogic.buildBreakdown(
+            players = listOf(alice),
+            units = mixedUnits,
+            fields = emptyList(),
+            localName = "Alice"
+        )
+
+        assertEquals(1, result.units)
+    }
+
+    @Test
+    fun `farmIncome plus fieldIncome equals player income`() {
+        val result = IncomeBreakdownLogic.buildBreakdown(
+            players = listOf(alice),
+            units = aliceUnits,
+            fields = aliceFields,
+            localName = "Alice"
+        )
+
+        assertEquals(
+            alice.income,
+            result.farmIncome + result.fieldIncome,
+            "Brutto-Aufschluesselung weicht von player.income ab -- " +
+                "Backend-Konstante geaendert? GOLD_PER_FARM/GOLD_PER_FIELD nachziehen."
+        )
+    }
+
+    @Test
+    fun `netIncome equals income minus upkeep`() {
+        val result = IncomeBreakdownLogic.buildBreakdown(
+            players = listOf(alice),
+            units = aliceUnits,
+            fields = aliceFields,
+            localName = "Alice"
+        )
+
+        assertEquals(alice.income - alice.upkeep, result.netIncome)
+    }
+}

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudLogicTest.kt
@@ -52,4 +52,41 @@ class TopHudLogicTest {
     fun `incomeFor returns 0 for empty players list`() {
         assertEquals(0, TopHudLogic.incomeFor(emptyList(), "Alice"))
     }
+
+    @Test
+    fun `netIncomeFor returns income minus upkeep`() {
+        val players = listOf(
+            Player(name = "Alice", color = PlayerColor.RED, gold = 3250, income = 120, upkeep = 50)
+        )
+        assertEquals(70, TopHudLogic.netIncomeFor(players, "Alice"))
+    }
+
+    @Test
+    fun `netIncomeFor returns negative value on insolvency`() {
+        val players = listOf(
+            Player(name = "Alice", color = PlayerColor.RED, gold = 0, income = 6, upkeep = 12)
+        )
+        assertEquals(-6, TopHudLogic.netIncomeFor(players, "Alice"))
+    }
+
+    @Test
+    fun `netIncomeFor returns 0 when local player is unknown`() {
+        val players = listOf(
+            Player(name = "Alice", color = PlayerColor.RED, gold = 3250, income = 120, upkeep = 50)
+        )
+        assertEquals(0, TopHudLogic.netIncomeFor(players, "Ghost"))
+    }
+
+    @Test
+    fun `netIncomeFor returns 0 when local name is null`() {
+        val players = listOf(
+            Player(name = "Alice", color = PlayerColor.RED, gold = 3250, income = 120, upkeep = 50)
+        )
+        assertEquals(0, TopHudLogic.netIncomeFor(players, null))
+    }
+
+    @Test
+    fun `netIncomeFor returns 0 for empty players list`() {
+        assertEquals(0, TopHudLogic.netIncomeFor(emptyList(), "Alice"))
+    }
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudStateTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudStateTest.kt
@@ -20,14 +20,17 @@ class TopHudStateTest {
     }
 
     @Test
-    fun `HudPopup has four entries`() {
-        assertEquals(4, HudPopup.entries.size)
+    fun `HudPopup has five entries`() {
+        assertEquals(5, HudPopup.entries.size)
     }
 
     @Test
-    fun `HudPopup contains None Menu Info Settings`() {
+    fun `HudPopup contains expected entries`() {
         val names = HudPopup.entries.map { it.name }.toSet()
-        assertEquals(setOf("None", "Menu", "Info", "Settings"), names)
+        assertEquals(
+            setOf("None", "Menu", "Info", "Settings", "Income"),
+            names
+        )
     }
 
     @Test

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHudViewModelTest.kt
@@ -52,4 +52,17 @@ class TopHudViewModelTest {
         vm.showSettings()
         assertEquals(HudPopup.Settings, vm.state.value.popup)
     }
+
+    @Test
+    fun `showIncome sets popup to Income`() {
+        vm.showIncome()
+        assertEquals(HudPopup.Income, vm.state.value.popup)
+    }
+
+    @Test
+    fun `showIncome from Menu replaces popup`() {
+        vm.openMenu()
+        vm.showIncome()
+        assertEquals(HudPopup.Income, vm.state.value.popup)
+    }
 }


### PR DESCRIPTION
## Summary

Adds the per-round income breakdown popup that opens when the player taps the income box in the top HUD. Switches the HUD income display from gross to net (red on negative). Drive-by: fixes farm price not growing in the bottom HUD.

**Was sich verändert:**
- Klick auf die Einkommen-Box im HUD öffnet ein Detail-Popup mit Aufschlüsselung pro Runde (Farmen, Felder, Brutto, Truppenunterhalt, Netto) -- genau wie im Mockup
- HUD zeigt jetzt **Netto** statt Brutto (grün bei ≥0, rot bei <0 für drohende Insolvenz)
- Farm-Preis im Bottom-HUD steigt jetzt korrekt pro gekaufter Farm (vorher blieb er bei 10 hängen)

## How it works
Server liefert `Player.income`, `Player.upkeep` und `Field.isSkeleton` bereits vollständig (über `recomputePlayerStats` vor jedem Broadcast).
Der Client:
- nutzt `Player.income` / `Player.upkeep` direkt als Source of Truth
- berechnet `farmIncome` und `fieldIncome` client-side **nur für die Anzeige** (z.B. "2 × 3 Gold = +6")
- ein `IncomeBreakdownLogicTest` enthält einen **Drift-Detektor**: `farmIncome + fieldIncome == player.income` -- wenn der Server die Konstanten ändert, schlägt der Test sofort an

## How to test
1. Spiel starten (mind. 2 Spieler), bis ein Match läuft
2. **HUD zeigt Netto:** Income-Box rechts oben zeigt z.B. `+0` (grün) bei Spielstart keine Felder, keine Truppen → 0 Brutto - 0 Upkeep
3. **Farm kaufen** → Gold sinkt um 10, Farm-Knopf zeigt Preis `11`
4. **Zweite Farm kaufen** → Preis `12`, HUD zeigt `+3` (1 Farm × 3 Gold) Test war vorher kaputt, Preis blieb auf 10
5. **Felder erobern** → HUD-Income steigt um +1 pro nicht-Skelett-Feld
6. **Einheiten kaufen** → Upkeep steigt: erste +3, zweite +4 (= -7 ges.), dritte +5 (= -12 ges.)
7. **Sobald Netto < 0:** HUD-Anzeige wechselt auf rot
8. **Klick auf Income-Box:** Popup öffnet sich mit voller Aufschlüsselung wie im Mockup
9. **Während Popup offen:** Farm kaufen → Popup-Werte aktualisieren sich live
10. **Klick auf "Schließen"** → Popup zu, HUD weiter sichtbar

## Tests
- `IncomeBreakdownLogicTest` (8 Tests): inkl. Drift-Detektor, Skelett-Filter, Truppen-Filter, Null-Safety
- `BottomHudLogicTest`: 12 Tests in den Farm-Bereichen auf `Player.farms` umgestellt; alle Edge-Cases (0 Farms, andere Spieler, Preis-Grenze) weiterhin abgedeckt
- `TopHudStateTest`: Anzahl der `HudPopup`-Werte (5 statt 4) und neuer `Income`-Eintrag geprüft