### PR TITLE
Feature reconnect

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -18,6 +18,8 @@ import at.aau.serg.websocketbrokerdemo.network.UnitMoveEndpoint
 import at.aau.serg.websocketbrokerdemo.ui.navigation.AppNavHost
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 
 class MainActivity : ComponentActivity() {
 
@@ -75,6 +77,32 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        // /leave nur bei "echtem" Verlassen senden — also wenn der User
+        // die App weggeswiped hat oder explizit aus dem Spiel raus ist
+        // (isFinishing). Bei Hintergrund / Display-Off greift die Server-
+        // Grace-Period, da soll NICHT geleaved werden.
+        //
+        // runBlocking + withTimeout, damit der STOMP-Frame zuverlaessig
+        // raus geht, bevor der Process stirbt. 500ms ist eine sichere
+        // Obergrenze (deutlich unter dem ANR-Limit von 5s und schon
+        // grosszuegig fuer einen einzelnen Send).
+        if (isFinishing) {
+            val repo = session.sessionRepository
+            val roomId = repo.roomId
+            val playerName = repo.playerName
+            if (!roomId.isNullOrBlank() && !playerName.isNullOrBlank()) {
+                try {
+                    runBlocking {
+                        withTimeout(LEAVE_TIMEOUT_MS) {
+                            endpoint.leaveGameAwait(roomId, playerName)
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "leaveGame on destroy failed/timed out", e)
+                }
+                repo.clear()
+            }
+        }
         super.onDestroy()
         stomp.disconnect()
         MusicManager.release()
@@ -82,5 +110,12 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         private const val TAG = "MainActivity"
+
+        /**
+         * Timeout fuer den /leave-Send-Frame in onDestroy. Klein genug
+         * um keinen ANR zu riskieren (Main-Thread blockiert), gross
+         * genug fuer einen Single-Frame-Send auf einer warmen WebSocket.
+         */
+        private const val LEAVE_TIMEOUT_MS = 500L
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
 
     private val stomp = Stomp()
     private val endpoint = UnitMoveEndpoint(stomp)
-    private val session = GameSession(endpoint)
+    private val session = GameSession(endpoint, connectionState = stomp.connectionState)
 
     override fun attachBaseContext(newBase: Context) {
         val lang = LanguageCache.get(newBase)
@@ -45,6 +45,22 @@ class MainActivity : ComponentActivity() {
             ).settings.first()
             MusicManager.applyMusicSettings(s.musicEnabled, s.musicVolume)
             MusicManager.applySfxSettings(s.sfxEnabled)
+        }
+
+        // Auto-/reconnect-Hook: sobald die Stomp-interne Reconnect-Loop
+        // den WebSocket wieder aufgebaut hat, schicken wir den /reconnect-
+        // Application-Call mit der gespeicherten Spieler-Identitaet, sodass
+        // der Server den Spieler wieder seinem Slot zuordnet. Wird nur
+        // geschickt, wenn aktuell ueberhaupt ein Match laeuft (roomId
+        // gesetzt) — in der Lobby ist nichts zu rejoinen.
+        stomp.onReconnected {
+            val repo = session.sessionRepository
+            val roomId = repo.roomId
+            val playerName = repo.playerName
+            val joinCode = repo.joinCode
+            if (!roomId.isNullOrBlank() && !playerName.isNullOrBlank() && !joinCode.isNullOrBlank()) {
+                endpoint.reconnect(roomId, playerName, joinCode)
+            }
         }
 
         // Connect STOMP once for the whole app session; then wire the error stream.

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/SessionRepository.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/SessionRepository.kt
@@ -1,0 +1,36 @@
+package at.aau.serg.websocketbrokerdemo.data
+
+/**
+ * In-Memory-Store fuer die Spieler-Identitaet im laufenden Match.
+ *
+ * Wird gebraucht, damit Reconnect- und Leave-Aufrufe den Server-Endpoints
+ * dieselben Daten mitgeben koennen, die der initiale Join verwendet hat
+ * — also den Spielernamen, den 6-stelligen Raum-Code und die Raum-UUID.
+ *
+ * Werte werden bewusst NICHT persistiert. Sprint-3-Scope: App-Kill =
+ * Spieler weg. Wer den Prozess killt, ist auch fuer den Server raus —
+ * der Reconnect deckt nur kurze WebSocket-Drops ab (Display-Off,
+ * Netzwechsel, Cell-Tower-Wechsel).
+ *
+ * Wiring: wird in [at.aau.serg.websocketbrokerdemo.MainActivity]
+ * instanziiert und ueber [at.aau.serg.websocketbrokerdemo.network.GameSession]
+ * an die ViewModels gereicht (kein DI-Framework im Projekt).
+ */
+class SessionRepository {
+
+    /** Anzeigename des lokalen Spielers (in der Wartelobby bestaetigt). */
+    var playerName: String? = null
+
+    /** 6-Zeichen-Join-Code des aktuellen Raums (Anzeige + Reconnect-Payload). */
+    var joinCode: String? = null
+
+    /** UUID des aktuellen Raums (Pfad-Segment fuer STOMP-Topics). */
+    var roomId: String? = null
+
+    /** Setzt alle Felder zurueck. Aufruf nach Spielende oder /leave. */
+    fun clear() {
+        playerName = null
+        joinCode = null
+        roomId = null
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/Player.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/Player.kt
@@ -30,6 +30,14 @@ package at.aau.serg.websocketbrokerdemo.data.serverside
  *                 diesem Match bereits einmal benutzt hat. Server-Truth,
  *                 damit der Geschenk-Button im HUD nicht client-side
  *                 umgangen werden kann.
+ *  - connected    Ob die WebSocket-Verbindung des Spielers gerade
+ *                 lebt. Default true (Server sendet auch im Reconnect-
+ *                 Pfad nichts auf alten Clients, dann gilt true). Wird
+ *                 vom Server auf false gesetzt sobald die Heartbeats
+ *                 ausbleiben; geht nach erfolgreichem /reconnect
+ *                 zurueck auf true oder verschwindet (Hard-Delete nach
+ *                 30s Grace-Period). UI zeigt waehrenddessen den
+ *                 DisconnectedPlayerOverlay.
  */
 data class Player(
     val name: String = "",
@@ -39,5 +47,6 @@ data class Player(
     val farms: Int = 0,
     val income: Int = 0,
     val upkeep: Int = 0,
-    val hasUsedGift: Boolean = false
+    val hasUsedGift: Boolean = false,
+    val connected: Boolean = true
 )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/ConnectionState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/ConnectionState.kt
@@ -1,0 +1,20 @@
+package at.aau.serg.websocketbrokerdemo.network
+
+/**
+ * Status der STOMP/WebSocket-Verbindung.
+ *
+ * Vom [Stomp] als StateFlow exponiert; UI-Schichten (z. B. das
+ * Reconnecting-Overlay im Game-Screen) reagieren darauf.
+ *
+ *  - [Connected]       Normalbetrieb, WebSocket steht.
+ *  - [Reconnecting]    WebSocket ist weggebrochen; Stomp probiert
+ *                      automatisch erneut. UI zeigt Wartebildschirm.
+ *  - [LostPermanently] Nach maximal vorgesehenen Versuchen kein
+ *                      erfolgreicher Wiederaufbau. UI bietet dem
+ *                      User die Rueckkehr zum Menue an.
+ */
+enum class ConnectionState {
+    Connected,
+    Reconnecting,
+    LostPermanently
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
@@ -5,6 +5,9 @@ import androidx.compose.runtime.mutableStateOf
 import at.aau.serg.websocketbrokerdemo.data.SessionRepository
 import at.aau.serg.websocketbrokerdemo.data.serverside.ErrorMessage
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * App-scoped holder for the live STOMP session.
@@ -32,6 +35,11 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.GameState
  *                        wird parallel beschrieben, damit Endpoints
  *                        ohne UI-Bezug (Activity-Lifecycle, Auto-
  *                        Reconnect-Callback) sauberen Zugriff haben.
+ *  - [connectionState]   Aktueller WebSocket-Status (Connected /
+ *                        Reconnecting / LostPermanently). Default ist
+ *                        ein statischer Connected-Flow; produktiv wird
+ *                        in der MainActivity der echte Stomp.connectionState
+ *                        durchgereicht.
  */
 class GameSession(
     val endpoint: UnitMoveEndpoint,
@@ -40,5 +48,7 @@ class GameSession(
     val gameState: MutableState<GameState?> = mutableStateOf(null),
     val lastError: MutableState<ErrorMessage?> = mutableStateOf(null),
     val localPlayerName: MutableState<String?> = mutableStateOf(null),
-    val sessionRepository: SessionRepository = SessionRepository()
+    val sessionRepository: SessionRepository = SessionRepository(),
+    val connectionState: StateFlow<ConnectionState> =
+        MutableStateFlow(ConnectionState.Connected).asStateFlow()
 )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
@@ -2,6 +2,7 @@ package at.aau.serg.websocketbrokerdemo.network
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import at.aau.serg.websocketbrokerdemo.data.SessionRepository
 import at.aau.serg.websocketbrokerdemo.data.serverside.ErrorMessage
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameState
 
@@ -24,6 +25,13 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.GameState
  *  - [localPlayerName]   Name des lokalen Spielers, vom WaitingLobby-
  *                        Screen gesetzt sobald der User seinen Namen
  *                        bestaetigt hat.
+ *  - [sessionRepository] In-Memory-Spiegel von roomId / joinCode /
+ *                        playerName fuer Reconnect- und Leave-Calls.
+ *                        Die einzelnen MutableState-Felder oben bleiben
+ *                        Source-of-Truth fuer die UI; das Repository
+ *                        wird parallel beschrieben, damit Endpoints
+ *                        ohne UI-Bezug (Activity-Lifecycle, Auto-
+ *                        Reconnect-Callback) sauberen Zugriff haben.
  */
 class GameSession(
     val endpoint: UnitMoveEndpoint,
@@ -31,5 +39,6 @@ class GameSession(
     val activeJoinCode: MutableState<String> = mutableStateOf(""),
     val gameState: MutableState<GameState?> = mutableStateOf(null),
     val lastError: MutableState<ErrorMessage?> = mutableStateOf(null),
-    val localPlayerName: MutableState<String?> = mutableStateOf(null)
+    val localPlayerName: MutableState<String?> = mutableStateOf(null),
+    val sessionRepository: SessionRepository = SessionRepository()
 )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/ReconnectLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/ReconnectLogic.kt
@@ -1,0 +1,43 @@
+package at.aau.serg.websocketbrokerdemo.network
+
+import kotlinx.coroutines.delay
+
+/**
+ * Pure Retry-Schleife fuer den Auto-Reconnect.
+ *
+ * Loest die Network-Klasse [Stomp] von der eigentlichen Schleifenlogik,
+ * damit das "wieviele Versuche im welchen Abstand"-Verhalten ohne
+ * StompClient-Mock unit-testbar bleibt: [Stomp] uebergibt eine
+ * suspendierende `attempt`-Funktion und einen Delay-Hook; der Test
+ * uebergibt eine Liste von booleschen Antworten und prueft Anzahl + Reihenfolge.
+ */
+object ReconnectLogic {
+
+    /**
+     * Versucht maximal [maxAttempts] Mal einen Connect.
+     *
+     * Bricht ab und liefert true, sobald [attempt] true zurueck gibt.
+     * Zwischen zwei Versuchen wartet die Funktion [delayMillis]
+     * Millisekunden. Liefert false wenn alle Versuche fehlschlagen.
+     *
+     * @param attempt   Connect-Logik. true = erfolgreich (Schleife endet),
+     *                  false = noch nicht verbunden (weiterer Versuch).
+     * @param delayFn   Wartefunktion zwischen zwei Versuchen.
+     *                  Default delegiert an [kotlinx.coroutines.delay];
+     *                  Tests koennen das ueberschreiben um virtuelle
+     *                  Zeit zu sparen.
+     */
+    suspend fun retryUntilSuccess(
+        maxAttempts: Int,
+        delayMillis: Long,
+        attempt: suspend () -> Boolean,
+        delayFn: suspend (Long) -> Unit = ::delay
+    ): Boolean {
+        require(maxAttempts >= 1) { "maxAttempts must be >= 1, was $maxAttempts" }
+        for (i in 1..maxAttempts) {
+            if (attempt()) return true
+            if (i < maxAttempts) delayFn(delayMillis)
+        }
+        return false
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
@@ -1,20 +1,26 @@
 package at.aau.serg.websocketbrokerdemo.network
 
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.hildan.krossbow.stomp.StompClient
 import org.hildan.krossbow.stomp.StompSession
+import org.hildan.krossbow.stomp.config.HeartBeat
 import org.hildan.krossbow.stomp.frame.FrameBody
 import org.hildan.krossbow.stomp.headers.StompSendHeaders
 import org.hildan.krossbow.stomp.subscribeText
 import org.hildan.krossbow.websocket.okhttp.OkHttpWebSocketClient
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Single STOMP entry-point for the whole app.
@@ -29,6 +35,16 @@ import org.hildan.krossbow.websocket.okhttp.OkHttpWebSocketClient
  *    keine Race-Condition mehr zwischen App-Start und erster Lobby-Aktion:
  *    der User kann sofort einen Raum erstellen oder beitreten, die Frames
  *    werden gepuffert/verzoegert bis der WebSocket steht.
+ *  - HeartBeat 20s/20s ist im StompClient konfiguriert (matched den
+ *    Server). Verhindert Idle-Timeout-Drops (Azure schliesst die WS
+ *    sonst nach ~120s ohne Traffic).
+ *  - Bei einem unerwarteten Disconnect (Display aus, Netzwechsel, Cell
+ *    Tower Wechsel, ...) faehrt [Stomp] automatisch eine Reconnect-Loop
+ *    (max [MAX_RECONNECT_ATTEMPTS] Versuche im [RECONNECT_DELAY_MS]
+ *    Abstand). Status ist ueber [connectionState] als StateFlow
+ *    beobachtbar; Subscriber koennen sich ueber [onReconnected] eine
+ *    Benachrichtigung holen, sobald die Verbindung wieder steht
+ *    (typischer Use-Case: dann den /reconnect-Application-Call senden).
  *
  * NOTE on content-type:
  *  - sendText  -> "text/plain"        (for /app/join)
@@ -44,13 +60,38 @@ class Stomp(
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val connectMutex = Mutex()
 
+    /**
+     * True sobald [disconnect] aufgerufen wurde. Verhindert dass die
+     * Auto-Reconnect-Loop nach einem absichtlichen Disconnect (App-Shutdown)
+     * weiter versucht zu verbinden.
+     */
+    @Volatile
+    private var intentionallyDisconnected = false
+
+    private val _connectionState = MutableStateFlow(ConnectionState.Connected)
+    val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+    private var reconnectJob: Job? = null
+    private val onReconnectedCallbacks = mutableListOf<() -> Unit>()
+    private val callbacksLock = Any()
+
     val isConnected: Boolean get() = session != null
+
+    /**
+     * Registriert einen Callback, der jedes Mal feuert, wenn die
+     * Auto-Reconnect-Loop einen STOMP-Wiederaufbau geschafft hat.
+     * Wird typischerweise vom GameViewModel genutzt, um danach den
+     * /reconnect-Application-Call zu senden.
+     */
+    fun onReconnected(callback: () -> Unit) {
+        synchronized(callbacksLock) { onReconnectedCallbacks += callback }
+    }
 
     /**
      * Verbindet zum STOMP-Broker, mit automatischem Retry um Azure-Cold-Start
      * abzufedern. Bei einem frisch gestarteten App-Backend dauert der erste
      * TLS-Handshake regelmaessig laenger als der OkHttp-Default-Timeout (10s);
-     * deshalb bis zu MAX_CONNECT_ATTEMPTS-mal probieren, mit einer kurzen
+     * deshalb bis zu [MAX_CONNECT_ATTEMPTS]-mal probieren, mit einer kurzen
      * Pause zwischen den Versuchen.
      *
      * Ist Mutex-geschuetzt, sodass parallele Aufrufer sich nicht doppelt
@@ -67,10 +108,9 @@ class Stomp(
             var lastError: Throwable? = null
             for (attempt in 1..MAX_CONNECT_ATTEMPTS) {
                 try {
-                    val c = StompClient(OkHttpWebSocketClient())
-                    client = c
-                    session = c.connect(websocketUri)
+                    doConnectOnce()
                     Log.i(TAG, "Connected to $websocketUri (attempt $attempt)")
+                    _connectionState.value = ConnectionState.Connected
                     return
                 } catch (e: Exception) {
                     lastError = e
@@ -96,7 +136,9 @@ class Stomp(
 
     /**
      * Abonniert ein STOMP-Topic. Wartet automatisch, bis STOMP verbunden
-     * ist (kein stiller No-Op mehr wie frueher).
+     * ist (kein stiller No-Op mehr wie frueher). Wenn der Subscribe-Flow
+     * endet (Server-Disconnect, Netzwerk weg, ...), wird der
+     * Auto-Reconnect getriggert.
      */
     fun subscribe(
         topic: String,
@@ -110,8 +152,14 @@ class Stomp(
                 return@launch
             }
             s.subscribeText(topic).collect { onMessage(it) }
+            // Subscribe-Flow normal beendet -> Session ist down.
+            Log.w(TAG, "Subscription to $topic ended (session closed)")
+            handleSessionLost("subscribe $topic ended")
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Subscription to $topic failed", e)
+            handleSessionLost("subscribe $topic threw")
         }
     }
 
@@ -163,6 +211,7 @@ class Stomp(
     }
 
     fun disconnect() {
+        intentionallyDisconnected = true
         scope.launch {
             try {
                 session?.disconnect()
@@ -171,6 +220,75 @@ class Stomp(
             } finally {
                 session = null
                 client = null
+            }
+        }
+    }
+
+    // ---- Internals ------------------------------------------------------
+
+    /** Einzelner Connect-Versuch mit HeartBeat-Config. */
+    private suspend fun doConnectOnce() {
+        val c = StompClient(OkHttpWebSocketClient()) {
+            heartBeat = HeartBeat(
+                minSendPeriod = HEARTBEAT_PERIOD,
+                expectedPeriod = HEARTBEAT_PERIOD,
+            )
+        }
+        client = c
+        session = c.connect(websocketUri)
+    }
+
+    /**
+     * Markiert die aktuelle Session als verloren und startet die
+     * Auto-Reconnect-Loop. Idempotent: wenn schon ein Reconnect laeuft
+     * oder der App-User absichtlich disconnected hat, passiert nichts.
+     */
+    private fun handleSessionLost(reason: String) {
+        if (intentionallyDisconnected) return
+        synchronized(callbacksLock) {
+            if (reconnectJob?.isActive == true) return
+            session = null
+            client = null
+            _connectionState.value = ConnectionState.Reconnecting
+            Log.w(TAG, "Session lost ($reason) -- starting reconnect loop")
+            reconnectJob = scope.launch {
+                val success = ReconnectLogic.retryUntilSuccess(
+                    maxAttempts = MAX_RECONNECT_ATTEMPTS,
+                    delayMillis = RECONNECT_DELAY_MS,
+                    attempt = { tryReconnectOnce() }
+                )
+                if (success) {
+                    Log.i(TAG, "Reconnect successful")
+                    _connectionState.value = ConnectionState.Connected
+                    fireReconnectedCallbacks()
+                } else {
+                    Log.e(TAG, "Reconnect failed after $MAX_RECONNECT_ATTEMPTS attempts")
+                    _connectionState.value = ConnectionState.LostPermanently
+                }
+            }
+        }
+    }
+
+    private suspend fun tryReconnectOnce(): Boolean {
+        return try {
+            connectMutex.withLock {
+                if (session != null) return@withLock true
+                doConnectOnce()
+                true
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Reconnect attempt failed: ${e.message}")
+            false
+        }
+    }
+
+    private fun fireReconnectedCallbacks() {
+        val snapshot = synchronized(callbacksLock) { onReconnectedCallbacks.toList() }
+        snapshot.forEach { cb ->
+            try {
+                cb()
+            } catch (e: Exception) {
+                Log.e(TAG, "onReconnected callback threw", e)
             }
         }
     }
@@ -188,6 +306,25 @@ class Stomp(
          * Pause zwischen zwei Connect-Versuchen in Millisekunden.
          */
         private const val RETRY_DELAY_MS = 2000L
+
+        /**
+         * Maximale Anzahl an Auto-Reconnect-Versuchen nach einem
+         * unerwarteten Disconnect. 15 * 2s = 30s und matched die Grace-
+         * Period des Servers (Spieler wird nach 30s aus dem Raum entfernt).
+         */
+        private const val MAX_RECONNECT_ATTEMPTS = 15
+
+        /**
+         * Pause zwischen zwei Auto-Reconnect-Versuchen in Millisekunden.
+         */
+        private const val RECONNECT_DELAY_MS = 2000L
+
+        /**
+         * STOMP-Heartbeat-Periode. 20s matched die Server-Konfiguration;
+         * zwei Heartbeats pro Minute halten die WebSocket im Azure-Idle-
+         * Timeout (120s) sicher offen.
+         */
+        private val HEARTBEAT_PERIOD = 20.seconds
 
         /**
          * Production backend on Azure. Use `wss://` (TLS) - the matching health endpoint is

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
@@ -194,20 +194,28 @@ class Stomp(
     fun sendJson(destination: String, json: String) {
         scope.launch {
             try {
-                awaitConnected()
-                val s = session
-                if (s == null) {
-                    Log.e(TAG, "sendJson($destination) aborted: session still null after awaitConnected")
-                    return@launch
-                }
-                s.send(
-                    StompSendHeaders(destination) { contentType = "application/json" },
-                    FrameBody.Text(json)
-                )
+                sendJsonAwait(destination, json)
             } catch (e: Exception) {
                 Log.e(TAG, "sendJson to $destination failed", e)
             }
         }
+    }
+
+    /**
+     * Suspending-Variante von [sendJson]. Faengt KEINE Exception ab — wird
+     * vom Caller umschlossen.
+     *
+     * Use-Case: Activity-Lifecycle-Calls wie /leave bei `onDestroy`, wo
+     * der Caller mit `runBlocking { withTimeout(...) { ... } }` warten
+     * muss bis der Frame raus ist, bevor der Process eventuell stirbt.
+     */
+    suspend fun sendJsonAwait(destination: String, json: String) {
+        awaitConnected()
+        val s = session ?: error("STOMP session still null after awaitConnected")
+        s.send(
+            StompSendHeaders(destination) { contentType = "application/json" },
+            FrameBody.Text(json)
+        )
     }
 
     fun disconnect() {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
@@ -163,6 +163,25 @@ class UnitMoveEndpoint(
         stomp.sendJsonAwait("/app/rooms/$roomId/leave", json)
     }
 
+    /**
+     * Meldet sich nach einem unerwarteten WebSocket-Drop wieder am Raum
+     * an. Wird ausgeloest, sobald die Auto-Reconnect-Loop in [Stomp]
+     * einen erfolgreichen WebSocket-Wiederaufbau gemeldet hat
+     * (siehe `Stomp.onReconnected`). Spieler-Identitaet kommt aus dem
+     * SessionRepository — Server prueft Name + JoinCode und re-attached
+     * den Spieler an seinen alten Slot, sofern er noch innerhalb der
+     * Grace-Period ist.
+     *
+     * Fire-and-forget: der Aufruf erfolgt im Hintergrund nach dem WS-
+     * Reconnect, kein Lifecycle-Druck wie bei /leave.
+     */
+    fun reconnect(roomId: String, playerName: String, joinCode: String) {
+        val payload = ReconnectRequest(playerName = playerName, joinCode = joinCode)
+        val json = gson.toJson(payload)
+        Log.d(TAG, "-> /app/rooms/$roomId/reconnect: $json")
+        stomp.sendJson("/app/rooms/$roomId/reconnect", json)
+    }
+
     private data class JoinRequest(val name: String, val color: String?)
     private data class ClaimGiftRequest(val playerName: String, val delta: Int)
     private data class StealResponseRequest(val playerName: String, val accept: Boolean)
@@ -170,6 +189,7 @@ class UnitMoveEndpoint(
     private data class BuyUnitRequest(val playerName: String, val type: String, val x: Int, val y: Int)
     private data class EndTurnRequest(val playerName: String)
     private data class LeaveRequest(val playerName: String)
+    private data class ReconnectRequest(val playerName: String, val joinCode: String)
 
     companion object { private const val TAG = "UnitMoveEndpoint" }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpoint.kt
@@ -144,12 +144,32 @@ class UnitMoveEndpoint(
         stomp.sendJson("/app/rooms/$roomId/end-turn", json)
     }
 
+    /**
+     * Verlaesst den Raum explizit. Wird vom Activity-Lifecycle-Hook
+     * (`onDestroy` mit `isFinishing == true`) aufgerufen, damit die
+     * Mitspieler den Spieler sofort als raus sehen — sonst greift die
+     * 30s-Grace-Period des Servers.
+     *
+     * Suspending, weil der Caller via `runBlocking { withTimeout(...) }`
+     * synchron warten muss, bis der STOMP-Frame raus ist, bevor der
+     * Process eventuell stirbt. Wirft die Exception weiter, damit der
+     * Caller (MainActivity) sie loggen kann ohne den Lifecycle zu
+     * blockieren.
+     */
+    suspend fun leaveGameAwait(roomId: String, playerName: String) {
+        val payload = LeaveRequest(playerName = playerName)
+        val json = gson.toJson(payload)
+        Log.d(TAG, "-> /app/rooms/$roomId/leave: $json")
+        stomp.sendJsonAwait("/app/rooms/$roomId/leave", json)
+    }
+
     private data class JoinRequest(val name: String, val color: String?)
     private data class ClaimGiftRequest(val playerName: String, val delta: Int)
     private data class StealResponseRequest(val playerName: String, val accept: Boolean)
     private data class BuyFarmRequest(val playerName: String)
     private data class BuyUnitRequest(val playerName: String, val type: String, val x: Int, val y: Int)
     private data class EndTurnRequest(val playerName: String)
+    private data class LeaveRequest(val playerName: String)
 
     companion object { private const val TAG = "UnitMoveEndpoint" }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -90,6 +90,11 @@ fun GameScreen(
 
     LaunchedEffect(status) {
         if (status == GameStatus.FINISHED) {
+            // Spiel ist vorbei -- die Reconnect-Identitaet wird nicht
+            // mehr gebraucht. Wir loeschen sie hier (statt im EndScreen),
+            // damit ein direktes "App wegswipen" auf dem EndScreen kein
+            // /leave fuer einen toten Raum mehr ausloest.
+            session.sessionRepository.clear()
             val winner = gameState?.winner
             val isWin = winner == localName
             val route = if (isWin) Screen.EndWin.route else Screen.EndLoss.route

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -16,11 +16,14 @@ import androidx.navigation.NavController
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
 import at.aau.serg.websocketbrokerdemo.grid.HexGridLogic
 import at.aau.serg.websocketbrokerdemo.grid.MapLayouts
+import at.aau.serg.websocketbrokerdemo.network.ConnectionState
 import at.aau.serg.websocketbrokerdemo.network.GameSession
 import at.aau.serg.websocketbrokerdemo.ui.game.bottomhud.BottomHud
 import at.aau.serg.websocketbrokerdemo.ui.game.bottomhud.components.PlacementOverlay
 import at.aau.serg.websocketbrokerdemo.ui.game.camera.CameraState
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.TopHud
+import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.DisconnectedPlayerOverlay
+import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.ReconnectingOverlay
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
 import androidx.compose.runtime.LaunchedEffect
 import at.aau.serg.websocketbrokerdemo.ui.navigation.Screen
@@ -76,6 +79,8 @@ fun GameScreen(
     val pendingGift = gameState?.pendingGift
     val currentTurn = gameState?.currentTurn
     val status = gameState?.status ?: GameStatus.WAITING_FOR_PLAYERS
+    val connectionState by session.connectionState.collectAsStateWithLifecycle()
+    val disconnectedNames = GameScreenLogic.disconnectedOtherPlayerNames(players, localName)
 
     // Wenn eine eigene Einheit selektiert ist, dunkle alle Felder ab,
     // die NICHT in Reichweite sind. Range = 2 nur wenn die Einheit auf
@@ -160,6 +165,23 @@ fun GameScreen(
                 onCancel = viewModel::cancelPlacement,
                 modifier = Modifier.align(Alignment.TopCenter)
             )
+        }
+
+        // Eigener Reconnect-Overlay liegt OBEN auf allem (auch ueber den
+        // DisconnectedPlayerOverlay), damit der lokale Spieler im Worst
+        // Case zuerst den eigenen Status sieht.
+        if (connectionState != ConnectionState.Connected) {
+            ReconnectingOverlay(
+                state = connectionState,
+                onBackToMenu = {
+                    session.sessionRepository.clear()
+                    navController.navigate(Screen.Home.route) {
+                        popUpTo(Screen.Home.route) { inclusive = false }
+                    }
+                }
+            )
+        } else if (disconnectedNames.isNotEmpty()) {
+            DisconnectedPlayerOverlay(disconnectedNames = disconnectedNames)
         }
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogic.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.unit.IntSize
 import at.aau.serg.websocketbrokerdemo.data.serverside.Field
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.Move
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
 import at.aau.serg.websocketbrokerdemo.grid.HexGridLogic
 import at.aau.serg.websocketbrokerdemo.grid.MapLayout
@@ -117,6 +118,23 @@ object GameScreenLogic {
         val target = findClickableUnit(units, move.toX, move.toY) ?: return false
         return target.player != localName
     }
+
+    /**
+     * Liefert die Namen aller Mitspieler (= NICHT der lokale Spieler),
+     * die laut Server-State gerade `connected == false` sind.
+     *
+     * Reihenfolge stabil (Eingangsreihenfolge), damit das UI keine
+     * Sortier-Sprünge produziert. Liefert eine leere Liste wenn nur der
+     * lokale Spieler weg ist (dann zeigt der eigene Reconnecting-Overlay
+     * — der DisconnectedPlayerOverlay ist nur fuer die ANDEREN gedacht).
+     */
+    fun disconnectedOtherPlayerNames(
+        players: List<Player>,
+        localName: String?
+    ): List<String> =
+        players
+            .filter { !it.connected && it.name != localName }
+            .map { it.name }
 
     /**
      * Berechnet die Felder, auf die [unit] in diesem Zug ziehen kann.

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/DisconnectedPlayerOverlay.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/DisconnectedPlayerOverlay.kt
@@ -1,0 +1,98 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinDark
+import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
+import at.aau.serg.websocketbrokerdemo.ui.theme.InkBrown
+import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentDark
+import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentLight
+import com.example.myapplication.R
+
+/**
+ * Vollbild-Overlay fuer die uebrigen Spieler, wenn ein Mitspieler die
+ * WebSocket-Verbindung verloren hat.
+ *
+ * Zeigt die Namen aller disconnecteten Spieler (Komma-separiert) sowie
+ * einen Wartebildschirm "Warte auf Reconnect…". Verschwindet automatisch
+ *  - sobald der disconnectete Spieler wieder connected ist (server
+ *    setzt Player.connected zurueck auf true), oder
+ *  - der Server den Spieler nach Ablauf der Grace-Period (~30s) aus
+ *    state.players entfernt hat — dann ist [disconnectedNames] leer
+ *    und der Overlay wird vom Aufrufer gar nicht erst gerendert.
+ *
+ * Schluckt alle Taps, damit das Spielfeld waehrend des Wartens nicht
+ * versehentlich bedient werden kann.
+ */
+@Composable
+fun DisconnectedPlayerOverlay(
+    disconnectedNames: List<String>
+) {
+    if (disconnectedNames.isEmpty()) return
+    val joined = disconnectedNames.joinToString(", ")
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.55f))
+            .pointerInput(Unit) { detectTapGestures { /* absorb */ } },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(32.dp)
+                .shadow(20.dp, RoundedCornerShape(16.dp))
+                .background(
+                    brush = Brush.verticalGradient(listOf(ParchmentLight, ParchmentDark)),
+                    shape = RoundedCornerShape(16.dp)
+                )
+                .border(3.dp, GoldCoinDark, RoundedCornerShape(16.dp))
+                .padding(24.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.disconnect_overlay_title, joined),
+                style = TextStyle(
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = InkBlack,
+                    textAlign = TextAlign.Center
+                )
+            )
+            Spacer(Modifier.height(16.dp))
+            CircularProgressIndicator(color = GoldCoinDark)
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.disconnect_overlay_subtitle),
+                style = TextStyle(
+                    fontSize = 13.sp,
+                    color = InkBrown,
+                    textAlign = TextAlign.Center
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/ReconnectingOverlay.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/ReconnectingOverlay.kt
@@ -1,0 +1,151 @@
+package at.aau.serg.websocketbrokerdemo.ui.game.tophud.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import at.aau.serg.websocketbrokerdemo.network.ConnectionState
+import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinDark
+import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinLight
+import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
+import at.aau.serg.websocketbrokerdemo.ui.theme.InkBrown
+import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentDark
+import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentLight
+import com.example.myapplication.R
+
+/**
+ * Vollbild-Overlay fuer den eigenen Spieler waehrend der App den
+ * WebSocket wieder aufzubauen versucht.
+ *
+ * Zwei Modi:
+ *  - [ConnectionState.Reconnecting]    Spinner + "Verbinde wieder…".
+ *    Verschwindet automatisch sobald der naechste State-Broadcast vom
+ *    Server reinkommt (also der Reconnect erfolgreich war).
+ *  - [ConnectionState.LostPermanently] "Verbindung verloren"-Panel mit
+ *    "Zurueck zum Menue"-Button. Wird angezeigt, wenn die Auto-Reconnect-
+ *    Loop alle Versuche aufgebraucht hat (≈ 30s, matched die Server-
+ *    Grace-Period).
+ *
+ * Schluckt alle Taps darunter, damit der Spieler waehrend des
+ * Reconnects keine Moves ausloest, die der Server eh ignoriert.
+ */
+@Composable
+fun ReconnectingOverlay(
+    state: ConnectionState,
+    onBackToMenu: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.6f))
+            .pointerInput(Unit) { detectTapGestures { /* absorb */ } },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(32.dp)
+                .shadow(20.dp, RoundedCornerShape(16.dp))
+                .background(
+                    brush = Brush.verticalGradient(listOf(ParchmentLight, ParchmentDark)),
+                    shape = RoundedCornerShape(16.dp)
+                )
+                .border(3.dp, GoldCoinDark, RoundedCornerShape(16.dp))
+                .padding(24.dp)
+        ) {
+            when (state) {
+                ConnectionState.Reconnecting -> ReconnectingBody()
+                ConnectionState.LostPermanently -> LostPermanentlyBody(onBackToMenu)
+                ConnectionState.Connected -> Unit
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReconnectingBody() {
+    Text(
+        text = stringResource(R.string.reconnect_overlay_title),
+        style = TextStyle(
+            fontSize = 22.sp,
+            fontWeight = FontWeight.ExtraBold,
+            color = InkBlack,
+            textAlign = TextAlign.Center
+        )
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+        text = stringResource(R.string.reconnect_overlay_subtitle),
+        style = TextStyle(
+            fontSize = 14.sp,
+            color = InkBrown,
+            textAlign = TextAlign.Center
+        )
+    )
+    Spacer(Modifier.height(24.dp))
+    CircularProgressIndicator(color = GoldCoinDark)
+}
+
+@Composable
+private fun LostPermanentlyBody(onBackToMenu: () -> Unit) {
+    Text(
+        text = stringResource(R.string.reconnect_lost_title),
+        style = TextStyle(
+            fontSize = 22.sp,
+            fontWeight = FontWeight.ExtraBold,
+            color = Color(0xFF8B1A1A),
+            textAlign = TextAlign.Center
+        )
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+        text = stringResource(R.string.reconnect_lost_subtitle),
+        style = TextStyle(
+            fontSize = 14.sp,
+            color = InkBrown,
+            textAlign = TextAlign.Center
+        )
+    )
+    Spacer(Modifier.height(24.dp))
+    Button(
+        onClick = onBackToMenu,
+        shape = RoundedCornerShape(8.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = GoldCoinDark,
+            contentColor = ParchmentLight
+        )
+    ) {
+        Text(
+            text = stringResource(R.string.reconnect_back_to_menu),
+            style = TextStyle(
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = GoldCoinLight,
+                letterSpacing = 1.sp
+            )
+        )
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
@@ -103,13 +103,17 @@ class LobbyViewModel(
             when (effect) {
                 is LobbyEffect.SetRoomId -> {
                     session.activeRoomId.value = effect.roomId
+                    session.sessionRepository.roomId = effect.roomId
                     // Neuer Raum: alle stale States aus vorherigen Spielen
                     // wegwerfen, damit die WaitingLobby nicht alte Spieler
                     // oder Fehler anzeigt.
                     session.gameState.value = null
                     session.lastError.value = null
                 }
-                is LobbyEffect.SetJoinCode -> session.activeJoinCode.value = effect.joinCode
+                is LobbyEffect.SetJoinCode -> {
+                    session.activeJoinCode.value = effect.joinCode
+                    session.sessionRepository.joinCode = effect.joinCode
+                }
                 is LobbyEffect.CloseJoinDialog -> _state.value = _state.value.copy(showJoinDialog = false)
                 is LobbyEffect.ShowError -> _lastError.value = effect.message
                 is LobbyEffect.NavigateToWaiting -> onSuccess()

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
@@ -60,6 +60,7 @@ fun LobbyNetworkSync(
     LaunchedEffect(localReady, localName, localColor) {
         if (localReady && localName.isNotBlank() && session.activeRoomId.value.isNotBlank()) {
             session.localPlayerName.value = localName
+            session.sessionRepository.playerName = localName
             session.endpoint.joinGame(
                 roomId = session.activeRoomId.value,
                 playerName = localName,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -115,4 +115,13 @@
 
     <!-- EndScreen -->
     <string name="end_screen_home">HAUPTMENÜ</string>
+
+    <!-- Reconnect / Disconnect overlays -->
+    <string name="reconnect_overlay_title">Verbinde wieder…</string>
+    <string name="reconnect_overlay_subtitle">Versuche den Server zu erreichen</string>
+    <string name="reconnect_lost_title">Verbindung verloren</string>
+    <string name="reconnect_lost_subtitle">Der Server kann nicht erreicht werden.</string>
+    <string name="reconnect_back_to_menu">Zurück zum Menü</string>
+    <string name="disconnect_overlay_title">%1$s hat die Verbindung verloren</string>
+    <string name="disconnect_overlay_subtitle">Warte auf Reconnect…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,4 +115,13 @@
 
     <!-- EndScreen -->
     <string name="end_screen_home">HOME</string>
+
+    <!-- Reconnect / Disconnect overlays -->
+    <string name="reconnect_overlay_title">Reconnecting…</string>
+    <string name="reconnect_overlay_subtitle">Trying to reach the server</string>
+    <string name="reconnect_lost_title">Connection lost</string>
+    <string name="reconnect_lost_subtitle">The server can\'t be reached.</string>
+    <string name="reconnect_back_to_menu">Back to menu</string>
+    <string name="disconnect_overlay_title">%1$s lost connection</string>
+    <string name="disconnect_overlay_subtitle">Waiting for reconnect…</string>
 </resources>

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/data/SessionRepositoryTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/data/SessionRepositoryTest.kt
@@ -1,0 +1,71 @@
+package at.aau.serg.websocketbrokerdemo.data
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests fuer [SessionRepository].
+ *
+ * Plain-class-Tests ohne Mocking: das Repository ist ein reiner In-Memory-
+ * State-Holder, also auch ohne Coroutines/Compose-Runtime testbar.
+ */
+class SessionRepositoryTest {
+
+    @Test
+    fun `defaults are all null`() {
+        val repo = SessionRepository()
+        assertNull(repo.playerName)
+        assertNull(repo.joinCode)
+        assertNull(repo.roomId)
+    }
+
+    @Test
+    fun `set values are read back`() {
+        val repo = SessionRepository()
+        repo.playerName = "Alice"
+        repo.joinCode = "CODE12"
+        repo.roomId = "uuid-1234"
+
+        assertEquals("Alice", repo.playerName)
+        assertEquals("CODE12", repo.joinCode)
+        assertEquals("uuid-1234", repo.roomId)
+    }
+
+    @Test
+    fun `clear resets all three fields`() {
+        val repo = SessionRepository().apply {
+            playerName = "Alice"
+            joinCode = "CODE12"
+            roomId = "uuid-1234"
+        }
+
+        repo.clear()
+
+        assertNull(repo.playerName)
+        assertNull(repo.joinCode)
+        assertNull(repo.roomId)
+    }
+
+    @Test
+    fun `clear on an already empty repository is a no-op`() {
+        val repo = SessionRepository()
+        repo.clear()
+        assertNull(repo.playerName)
+        assertNull(repo.joinCode)
+        assertNull(repo.roomId)
+    }
+
+    @Test
+    fun `setting one field does not touch the others`() {
+        val repo = SessionRepository().apply {
+            playerName = "Alice"
+            joinCode = "CODE12"
+        }
+        repo.roomId = "uuid-1234"
+
+        assertEquals("Alice", repo.playerName)
+        assertEquals("CODE12", repo.joinCode)
+        assertEquals("uuid-1234", repo.roomId)
+    }
+}

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/data/serverside/PlayerTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/data/serverside/PlayerTest.kt
@@ -20,4 +20,18 @@ class PlayerTest {
         assertEquals("session-123", player.sessionId)
         assertEquals(PlayerColor.BLUE, player.color)
     }
+
+    @Test
+    fun `Player connected defaults to true`() {
+        // Default true ist wichtig: alte GameState-Broadcasts vom Server,
+        // die noch nicht das connected-Feld serialisieren, sollen den
+        // Spieler nicht faelschlich als disconnected zeigen.
+        assertTrue(Player().connected)
+    }
+
+    @Test
+    fun `Player connected can be set to false`() {
+        val player = Player(name = "Bob", connected = false)
+        assertFalse(player.connected)
+    }
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/ReconnectLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/ReconnectLogicTest.kt
@@ -1,0 +1,113 @@
+package at.aau.serg.websocketbrokerdemo.network
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Tests fuer [ReconnectLogic.retryUntilSuccess].
+ *
+ * Verwendet einen fake-Delay-Hook anstelle des echten `delay()`, sodass
+ * die Tests sofort durchlaufen — die Logik darf nicht von realer Wallclock-
+ * Zeit abhaengen.
+ */
+class ReconnectLogicTest {
+
+    private val recordedDelays = mutableListOf<Long>()
+    private val fakeDelay: suspend (Long) -> Unit = { recordedDelays += it }
+
+    @Test
+    fun `returns true on first attempt success without delaying`() = runTest {
+        var attempts = 0
+        val result = ReconnectLogic.retryUntilSuccess(
+            maxAttempts = 5,
+            delayMillis = 100,
+            attempt = { attempts++; true },
+            delayFn = fakeDelay
+        )
+        assertTrue(result)
+        assertEquals(1, attempts)
+        assertEquals(0, recordedDelays.size)
+    }
+
+    @Test
+    fun `returns true when success comes on later attempt`() = runTest {
+        var attempts = 0
+        val result = ReconnectLogic.retryUntilSuccess(
+            maxAttempts = 5,
+            delayMillis = 100,
+            attempt = { attempts++; attempts == 3 },
+            delayFn = fakeDelay
+        )
+        assertTrue(result)
+        assertEquals(3, attempts)
+        // 2 delays between 3 attempts
+        assertEquals(listOf(100L, 100L), recordedDelays)
+    }
+
+    @Test
+    fun `returns false when all attempts fail`() = runTest {
+        var attempts = 0
+        val result = ReconnectLogic.retryUntilSuccess(
+            maxAttempts = 4,
+            delayMillis = 50,
+            attempt = { attempts++; false },
+            delayFn = fakeDelay
+        )
+        assertFalse(result)
+        assertEquals(4, attempts)
+    }
+
+    @Test
+    fun `does not delay after the last failed attempt`() = runTest {
+        ReconnectLogic.retryUntilSuccess(
+            maxAttempts = 3,
+            delayMillis = 250,
+            attempt = { false },
+            delayFn = fakeDelay
+        )
+        // 3 attempts -> 2 delays (between attempts), no trailing delay
+        assertEquals(2, recordedDelays.size)
+    }
+
+    @Test
+    fun `single attempt with failure returns false and does not delay`() = runTest {
+        var attempts = 0
+        val result = ReconnectLogic.retryUntilSuccess(
+            maxAttempts = 1,
+            delayMillis = 999,
+            attempt = { attempts++; false },
+            delayFn = fakeDelay
+        )
+        assertFalse(result)
+        assertEquals(1, attempts)
+        assertEquals(0, recordedDelays.size)
+    }
+
+    @Test
+    fun `single attempt with success returns true`() = runTest {
+        val result = ReconnectLogic.retryUntilSuccess(
+            maxAttempts = 1,
+            delayMillis = 999,
+            attempt = { true },
+            delayFn = fakeDelay
+        )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `rejects maxAttempts less than 1`() {
+        assertThrows<IllegalArgumentException> {
+            kotlinx.coroutines.runBlocking {
+                ReconnectLogic.retryUntilSuccess(
+                    maxAttempts = 0,
+                    delayMillis = 100,
+                    attempt = { true }
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
@@ -8,6 +8,8 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
 import at.aau.serg.websocketbrokerdemo.data.serverside.Move
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
 import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
+import io.mockk.coJustRun
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -15,6 +17,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -290,8 +293,35 @@ class UnitMoveEndpointTest {
         }
     }
 
+    // ---- leaveGameAwait ------------------------------------------------
 
+    @Test
+    fun `leaveGameAwait sends correct JSON via sendJsonAwait`() = runBlocking {
+        coJustRun { stomp.sendJsonAwait(any(), any()) }
 
+        endpoint.leaveGameAwait("game1", "Alice")
+
+        coVerify {
+            stomp.sendJsonAwait(
+                "/app/rooms/game1/leave",
+                """{"playerName":"Alice"}"""
+            )
+        }
+    }
+
+    @Test
+    fun `leaveGameAwait uses the room id provided`() = runBlocking {
+        coJustRun { stomp.sendJsonAwait(any(), any()) }
+
+        endpoint.leaveGameAwait("arena-99", "Bob")
+
+        coVerify {
+            stomp.sendJsonAwait(
+                destination = "/app/rooms/arena-99/leave",
+                json = any()
+            )
+        }
+    }
 
     // ---- subscribeToGameState ------------------------------------------
 

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/network/UnitMoveEndpointTest.kt
@@ -323,6 +323,32 @@ class UnitMoveEndpointTest {
         }
     }
 
+    // ---- reconnect -----------------------------------------------------
+
+    @Test
+    fun `reconnect sends correct JSON with playerName and joinCode`() {
+        endpoint.reconnect("game1", "Alice", "CODE12")
+
+        verify {
+            stomp.sendJson(
+                "/app/rooms/game1/reconnect",
+                """{"playerName":"Alice","joinCode":"CODE12"}"""
+            )
+        }
+    }
+
+    @Test
+    fun `reconnect uses the room id provided`() {
+        endpoint.reconnect("arena-7", "Bob", "AAA111")
+
+        verify {
+            stomp.sendJson(
+                destination = "/app/rooms/arena-7/reconnect",
+                json = any()
+            )
+        }
+    }
+
     // ---- subscribeToGameState ------------------------------------------
 
     @Test

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogicTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.unit.IntSize
 import at.aau.serg.websocketbrokerdemo.data.serverside.Field
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameUnit
 import at.aau.serg.websocketbrokerdemo.data.serverside.Move
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
 import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
 import at.aau.serg.websocketbrokerdemo.grid.HexGridLogic
 import at.aau.serg.websocketbrokerdemo.grid.MapLayout
@@ -359,5 +360,51 @@ class GameScreenLogicTest {
             assertTrue(col in 0 until testLayout.cols)
             assertTrue(row in 0 until testLayout.rows)
         }
+    }
+
+    // ---- disconnectedOtherPlayerNames --------------------------------
+
+    private fun player(name: String, connected: Boolean) =
+        Player(name = name, connected = connected)
+
+    @Test
+    fun `disconnectedOtherPlayerNames leer wenn alle connected`() {
+        val players = listOf(player(alice, true), player(bob, true))
+        val result = GameScreenLogic.disconnectedOtherPlayerNames(players, alice)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `disconnectedOtherPlayerNames listet andere disconnectete Spieler`() {
+        val players = listOf(player(alice, true), player(bob, false))
+        val result = GameScreenLogic.disconnectedOtherPlayerNames(players, alice)
+        assertEquals(listOf(bob), result)
+    }
+
+    @Test
+    fun `disconnectedOtherPlayerNames ignoriert den lokalen Spieler selbst`() {
+        val players = listOf(player(alice, false), player(bob, true))
+        val result = GameScreenLogic.disconnectedOtherPlayerNames(players, alice)
+        // Alice ist der lokale Spieler -> der eigene Reconnecting-Overlay
+        // uebernimmt; diese Liste soll nur die ANDEREN abdecken.
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `disconnectedOtherPlayerNames listet mehrere Disconnects`() {
+        val players = listOf(
+            player(alice, true),
+            player(bob, false),
+            player("Carol", false)
+        )
+        val result = GameScreenLogic.disconnectedOtherPlayerNames(players, alice)
+        assertEquals(listOf(bob, "Carol"), result)
+    }
+
+    @Test
+    fun `disconnectedOtherPlayerNames mit null localName behandelt alle als andere`() {
+        val players = listOf(player(alice, false), player(bob, false))
+        val result = GameScreenLogic.disconnectedOtherPlayerNames(players, null)
+        assertEquals(listOf(alice, bob), result)
     }
 }


### PR DESCRIPTION
PR umfasst drei aufeinander aufbauende Sub-Issues fuer den App-seitigen Reconnect-Flow 

## Sub-Issue A — Network Foundation (Heartbeat + Auto-Reconnect-Loop)

Krossbow STOMP-Heartbeats 20s/20s konfiguriert (matched den Server, verhindert Azure-Idle-Timeout-Drops).
Auto-Reconnect-Loop: wenn der Subscribe-Flow endet oder bricht, faehrt Stomp eine Retry-Schleife (max 15 Versuche im 2s-Abstand ≈ 30s = Server-Grace-Period).
Neuer ConnectionState-Enum (Connected / Reconnecting / LostPermanently) als StateFlow exponiert.
onReconnected-Callback-Registry fuer Subscriber, die nach erfolgreichem WS-Wiederaufbau reagieren wollen.
Pure ReconnectLogic.retryUntilSuccess mit injizierbarem Delay-Hook (vollstaendig unit-testbar).

## Sub-Issue B — SessionRepository + /leave-Endpoint

Neue plain class SessionRepository (in-memory) fuer playerName / joinCode / roomId, ueber GameSession an die ViewModels gereicht.
Schreibstellen: LobbyViewModel spiegelt SetRoomId/SetJoinCode-Effekte ins Repo, LobbyNetworkSync setzt den Namen beim Ready-Klick.
clear() beim Spielende im GameScreen (FINISHED-Status).
Neuer /leave-Endpoint via leaveGameAwait (suspending) plus Stomp.sendJsonAwait damit der Frame synchron rausgeht.
MainActivity.onDestroy ruft /leave nur bei isFinishing == true (App weggewischt / aus Game zurueck) — onStop/onPause bleiben stumm, damit die Server-Grace-Period bei Display-Off greifen kann. runBlocking { withTimeout(500ms) } haelt das ANR-Risiko gering.

## Sub-Issue C — Reconnect-UI und Disconnect-Anzeige

Player.connected: Boolean = true als neues Feld im DTO (Default true, damit alte Broadcasts nicht faelschlich als disconnected angezeigt werden).
/reconnect-Endpoint via UnitMoveEndpoint.reconnect(roomId, playerName, joinCode).
MainActivity haengt sich an stomp.onReconnected und schickt /reconnect automatisch mit den Werten aus SessionRepository — nur wenn aktuell ein Match laeuft.
connectionState durch GameSession an die UI weitergereicht.
ReconnectingOverlay fuer den eigenen Spieler: Pergament-Panel mit Spinner und „Verbinde wieder…", bei LostPermanently mit rotem Titel und „Zurueck zum Menue"-Button.
DisconnectedPlayerOverlay fuer die anderen Spieler: zeigt Komma-separierte Namensliste der disconnecteten Mitspieler. Verschwindet automatisch bei Reconnect oder Hard-Delete.
Beide Overlays liegen oben im GameScreen und schlucken Taps; der eigene Reconnecting-Overlay hat Vorrang vor der Peer-Anzeige.
Pure Helper GameScreenLogic.disconnectedOtherPlayerNames (lokalen Spieler raus, stabile Reihenfolge).
String-Resources de/en fuer beide Overlays.
Tests neu/erweitert: ReconnectLogicTest, SessionRepositoryTest, neue Cases in UnitMoveEndpointTest (leaveGameAwait, reconnect), PlayerTest (connected-Default), GameScreenLogicTest (disconnectedOtherPlayerNames)