### PR TITLE
multiplayer bug fix and refactor

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -60,6 +60,10 @@ class MainActivity : ComponentActivity() {
             val joinCode = repo.joinCode
             if (!roomId.isNullOrBlank() && !playerName.isNullOrBlank() && !joinCode.isNullOrBlank()) {
                 endpoint.reconnect(roomId, playerName, joinCode)
+                // Idempotenter /init-Call: triggert einen zweiten State-Broadcast,
+                // falls der durch /reconnect ausgeloeste Broadcast den frisch
+                // wieder aufgebauten Subscriber knapp verpasst.
+                endpoint.requestRoomState(roomId)
             }
         }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -135,31 +137,45 @@ class Stomp(
     suspend fun awaitConnected() = connect()
 
     /**
-     * Abonniert ein STOMP-Topic. Wartet automatisch, bis STOMP verbunden
-     * ist (kein stiller No-Op mehr wie frueher). Wenn der Subscribe-Flow
-     * endet (Server-Disconnect, Netzwerk weg, ...), wird der
-     * Auto-Reconnect getriggert.
+     * Abonniert ein STOMP-Topic und re-subscribed automatisch nach jedem
+     * unerwarteten WebSocket-Drop. Wartet beim ersten Aufruf bis STOMP
+     * verbunden ist; wenn der Subscribe-Flow danach endet (Server-
+     * Disconnect, Netzwerk weg, ...), wird der Auto-Reconnect getriggert
+     * und nach dessen Erfolg automatisch neu auf das Topic abonniert.
+     * Ohne diese Schleife wuerde der urspruengliche collect-Coroutine
+     * nach einem Drop einfach auslaufen und der Client wuerde keine
+     * Broadcasts mehr empfangen, obwohl der WebSocket wieder steht.
+     *
+     * Beendet sich erst bei [disconnect] (intentionallyDisconnected),
+     * bei [ConnectionState.LostPermanently] oder wenn der zurueck-
+     * gegebene Job gecancelt wird.
      */
     fun subscribe(
         topic: String,
         onMessage: (String) -> Unit
     ): Job = scope.launch {
-        try {
-            awaitConnected()
-            val s = session
-            if (s == null) {
-                Log.e(TAG, "subscribe($topic) aborted: session still null after awaitConnected")
-                return@launch
+        while (isActive && !intentionallyDisconnected) {
+            try {
+                awaitConnected()
+                val s = session
+                if (s == null) {
+                    Log.e(TAG, "subscribe($topic) aborted: session still null after awaitConnected")
+                } else {
+                    s.subscribeText(topic).collect { onMessage(it) }
+                    Log.w(TAG, "Subscription to $topic ended (session closed)")
+                    handleSessionLost("subscribe $topic ended")
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Subscription to $topic failed", e)
+                handleSessionLost("subscribe $topic threw")
             }
-            s.subscribeText(topic).collect { onMessage(it) }
-            // Subscribe-Flow normal beendet -> Session ist down.
-            Log.w(TAG, "Subscription to $topic ended (session closed)")
-            handleSessionLost("subscribe $topic ended")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Log.e(TAG, "Subscription to $topic failed", e)
-            handleSessionLost("subscribe $topic threw")
+            if (intentionallyDisconnected) break
+            val next = connectionState.first {
+                it == ConnectionState.Connected || it == ConnectionState.LostPermanently
+            }
+            if (next == ConnectionState.LostPermanently) break
         }
     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -93,15 +93,25 @@ fun GameScreen(
             setOf(selected.x to selected.y)
     } ?: emptySet()
 
-    LaunchedEffect(status) {
-        if (status == GameStatus.FINISHED) {
+    LaunchedEffect(status, gameState?.players) {
+        val state = gameState ?: return@LaunchedEffect
+        val name = localName ?: return@LaunchedEffect
+
+        // Im 3-/4-Spieler-Modus bleibt der GameStatus nach dem Ausscheiden
+        // eines Spielers auf IN_PROGRESS — der Verlierer wird vom Server
+        // einfach aus state.players entfernt (siehe GameService.eliminatePlayer).
+        // Daher zusaetzlich pruefen, ob der lokale Spieler noch in der Liste
+        // steht; falls nicht, ist er raus und gehoert auf den LossScreen.
+        val iAmEliminated = state.players.none { it.name == name }
+        val gameOver = status == GameStatus.FINISHED
+
+        if (iAmEliminated || gameOver) {
             // Spiel ist vorbei -- die Reconnect-Identitaet wird nicht
             // mehr gebraucht. Wir loeschen sie hier (statt im EndScreen),
             // damit ein direktes "App wegswipen" auf dem EndScreen kein
             // /leave fuer einen toten Raum mehr ausloest.
             session.sessionRepository.clear()
-            val winner = gameState?.winner
-            val isWin = winner == localName
+            val isWin = state.winner == name
             val route = if (isWin) Screen.EndWin.route else Screen.EndLoss.route
             navController.navigate(route) {
                 // Clear the backstack up to Home to avoid going back into the finished game

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/WaitingLobbyViewModel.kt
@@ -102,53 +102,61 @@ class WaitingLobbyViewModel(
      * ein anderer Spieler schon hat.
      */
     fun applyRemoteState(remotePlayers: List<Player>) {
-        val currentSlots = _state.value.slots
+        val mapped = mapRemoteSlots(_state.value.slots, remotePlayers)
+        updateSlots(reassignLocalColorIfTaken(mapped))
+    }
 
-        var newSlots = currentSlots.mapIndexed { index, slot ->
-            if (slot.isLocal) {
-                slot
-            } else {
-                val remoteIndex = index - 1
-                val remotePlayer = remotePlayers.getOrNull(remoteIndex)
-                if (remotePlayer == null) {
-                    slot.copy(status = SlotStatus.Empty, name = "", ready = false)
-                } else {
-                    slot.copy(
-                        status = SlotStatus.Player,
-                        name = remotePlayer.name,
-                        color = remotePlayer.color,
-                        ready = true,
-                        isLocal = false
-                    )
-                }
-            }
+    /**
+     * Baut die Slot-Liste aus der Server-Spielerliste neu auf.
+     *
+     * Der lokale Slot 0 bleibt unangetastet; die Remote-Slots 1..n werden
+     * mit den Server-Spielern befuellt -- oder als leer markiert, wenn an
+     * der jeweiligen Position kein Spieler (mehr) ist. Die Remote-Farben
+     * werden 1:1 aus dem Server-GameState uebernommen, damit der Color-
+     * Picker konsistent zeigt, welche Farben belegt sind.
+     */
+    private fun mapRemoteSlots(
+        currentSlots: List<PlayerSlot>,
+        remotePlayers: List<Player>
+    ): List<PlayerSlot> =
+        currentSlots.mapIndexed { index, slot ->
+            if (slot.isLocal) return@mapIndexed slot
+
+            val remotePlayer = remotePlayers.getOrNull(index - 1)
+                ?: return@mapIndexed slot.copy(status = SlotStatus.Empty, name = "", ready = false)
+
+            slot.copy(
+                status = SlotStatus.Player,
+                name = remotePlayer.name,
+                color = remotePlayer.color,
+                ready = true,
+                isLocal = false
+            )
         }
 
-        // Auto-Reassign: wenn der lokale Slot eine Farbe hat, die ein
-        // Remote-Spieler bereits belegt, UND der User noch nicht "ready"
-        // geklickt hat, vergeben wir automatisch die naechste freie Farbe.
-        // Damit muss der User nicht jedes Mal manuell wechseln, wenn sein
-        // RED-Default mit dem RED-Default des Hosts kollidiert.
-        // Wenn der User schon bewusst ready geklickt hat, lassen wir seine
-        // Wahl unangetastet -- ein Color-Konflikt wird dann vom Server
-        // ueber COLOR_ALREADY_TAKEN abgefangen.
-        val localSlot = newSlots.firstOrNull { it.isLocal }
-        if (localSlot != null && !localSlot.ready) {
-            val remoteColors = newSlots
-                .filter { !it.isLocal && it.status != SlotStatus.Empty }
-                .map { it.color }
-                .toSet()
-            if (localSlot.color in remoteColors) {
-                val freeColor = PlayerColor.entries.firstOrNull { it !in remoteColors }
-                if (freeColor != null) {
-                    newSlots = newSlots.map { s ->
-                        if (s.isLocal) s.copy(color = freeColor) else s
-                    }
-                }
-            }
-        }
+    /**
+     * Auto-Reassign: wenn der lokale Slot eine Farbe hat, die ein
+     * Remote-Spieler bereits belegt, UND der User noch nicht "ready"
+     * geklickt hat, vergeben wir automatisch die naechste freie Farbe.
+     * Damit muss der User nicht jedes Mal manuell wechseln, wenn sein
+     * RED-Default mit dem RED-Default des Hosts kollidiert.
+     *
+     * Wenn der User schon bewusst ready geklickt hat, lassen wir seine
+     * Wahl unangetastet -- ein Color-Konflikt wird dann vom Server ueber
+     * COLOR_ALREADY_TAKEN abgefangen.
+     */
+    private fun reassignLocalColorIfTaken(slots: List<PlayerSlot>): List<PlayerSlot> {
+        val localSlot = slots.firstOrNull { it.isLocal } ?: return slots
+        if (localSlot.ready) return slots
 
-        updateSlots(newSlots)
+        val remoteColors = slots
+            .filter { !it.isLocal && it.status != SlotStatus.Empty }
+            .map { it.color }
+            .toSet()
+        if (localSlot.color !in remoteColors) return slots
+
+        val freeColor = PlayerColor.entries.firstOrNull { it !in remoteColors } ?: return slots
+        return slots.map { s -> if (s.isLocal) s.copy(color = freeColor) else s }
     }
 
     // ---- Fehler-Handling -----------------------------------------------


### PR DESCRIPTION
## Two multiplayer bugs:
1. STOMP subscriptions died permanently after a WebSocket drop. The
   collect coroutine simply ran out once the session closed, so even
   after auto-reconnect re-established the socket the client never
   received any further broadcasts. subscribe() now loops: on a drop it
   triggers the reconnect, waits for Connected, and re-subscribes to the
   topic. It stops only on intentional disconnect, LostPermanently, or
   job cancellation. The onReconnected hook additionally fires an
   idempotent requestRoomState() so a freshly re-subscribed client still
   gets the current state if it narrowly missed the /reconnect broadcast.
   
2. In 3-/4-player modes an eliminated player was never sent to the loss
   screen: the server keeps the game IN_PROGRESS and just removes the
   loser from state.players, so the FINISHED-only check never fired. The
   game-over effect now also navigates to the end screen when the local
   player is no longer present in state.players.
   
   ## Fixed cognitive complecity in WaitingLobbyViewModel