### PR TITLE
Feature unit visual deployment

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexGrid.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexGrid.kt
@@ -32,6 +32,7 @@ fun HexGrid(
     fields: List<Field>,
     players: List<Player>,
     darkenedCells: Set<Pair<Int, Int>> = emptySet(),
+    highlightedCells: Set<Pair<Int, Int>> = emptySet(),
     modifier: Modifier = Modifier
 ) {
     val renderer = remember { HexRenderer() }
@@ -57,7 +58,10 @@ fun HexGrid(
 
     Canvas(modifier = modifier) {
         with(renderer) {
-            render(layout, units, buildings, fields, players, unitPainters, buildingPainters, darkenedCells)
+            render(
+                layout, units, buildings, fields, players,
+                unitPainters, buildingPainters, darkenedCells, highlightedCells
+            )
         }
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexRenderer.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/grid/HexRenderer.kt
@@ -50,7 +50,8 @@ class HexRenderer {
         players: List<Player>,
         unitPainters: Map<Pair<PlayerColor, UnitType>, Painter>,
         buildingPainters: Map<Pair<PlayerColor, BuildingType>, Painter>,
-        darkenedCells: Set<Pair<Int, Int>> = emptySet()
+        darkenedCells: Set<Pair<Int, Int>> = emptySet(),
+        highlightedCells: Set<Pair<Int, Int>> = emptySet()
     ) {
         val unitsByPosition = units.associateBy { it.x to it.y }
         val buildingsByPosition = buildings.associateBy { it.x to it.y }
@@ -65,6 +66,14 @@ class HexRenderer {
             fieldsByPosition[col to row]?.owner?.let { owner ->
                 val fillColor = PlayerColorMap.cellFillFor(owner, players)
                 drawCellFill(cx, cy, layout.hexSize, fillColor)
+            }
+
+            // Gueltige Zielfelder (Platzieren/Bewegen) hell ueberlagern, damit
+            // sie auch bei dunklen Spielerfarben (z. B. Blau) klar als "offen"
+            // erkennbar sind. Der Schein liegt UNTER den Icons (die kommen
+            // weiter unten), aber ueber der Owner-Fuellung.
+            if ((col to row) in highlightedCells) {
+                drawCellFill(cx, cy, layout.hexSize, HIGHLIGHT_FILL)
             }
 
             drawHex(cx, cy, layout.hexSize)
@@ -93,6 +102,16 @@ class HexRenderer {
                 drawCellFill(cx, cy, layout.hexSize, Color(0f, 0f, 0f, 0.45f))
             }
         }
+
+        // Gueltige Zielfelder zum Schluss mit einem kraeftigen Gold-Rand
+        // umranden (ueber Icons + Darken-Overlay), damit sie deutlich
+        // "aufleuchten" und sich klar vom Rest abheben.
+        if (highlightedCells.isNotEmpty()) {
+            for ((col, row) in highlightedCells) {
+                val (cx, cy) = HexGridLogic.cellCenter(col, row, layout)
+                drawHexStroke(cx, cy, layout.hexSize, HIGHLIGHT_BORDER, HIGHLIGHT_STROKE)
+            }
+        }
     }
 
     /**
@@ -109,13 +128,23 @@ class HexRenderer {
     }
 
     /** Einzelner Hex als geschlossener Pfad mit schwarzem Rand. */
-    private fun DrawScope.drawHex(cx: Float, cy: Float, size: Float) {
+    private fun DrawScope.drawHex(cx: Float, cy: Float, size: Float) =
+        drawHexStroke(cx, cy, size, Color.Black, 3f)
+
+    /** Hex-Umrandung in beliebiger Farbe/Strichstaerke. */
+    private fun DrawScope.drawHexStroke(
+        cx: Float,
+        cy: Float,
+        size: Float,
+        color: Color,
+        width: Float
+    ) {
         val path = Path()
         HexGridLogic.hexCorners(cx, cy, size).forEachIndexed { i, (x, y) ->
             if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
         }
         path.close()
-        drawPath(path, Color.Black, style = Stroke(3f))
+        drawPath(path, color, style = Stroke(width))
     }
 
     /** Einheit als Icon-Painter. */
@@ -155,5 +184,21 @@ class HexRenderer {
                 draw(size = Size(iconSize, iconSize))
             }
         }
+    }
+
+    private companion object {
+        /**
+         * Dezenter heller Schein ueber gueltigen Zielfeldern -- hellt dunkle
+         * Farben nur leicht auf, sodass die Spielerfarbe darunter sichtbar
+         * bleibt. Der goldene Rand ([HIGHLIGHT_BORDER]) ist der eigentliche
+         * Hervorhebungs-Indikator.
+         */
+        val HIGHLIGHT_FILL = Color(1f, 1f, 1f, 0.01f)
+
+        /** Kraeftiger Gold-Rand, der gueltige Zielfelder umrandet. */
+        val HIGHLIGHT_BORDER = Color(0xFFFFE082)
+
+        /** Strichstaerke des Highlight-Rands (dicker als der normale Hex-Rand). */
+        const val HIGHLIGHT_STROKE = 6f
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameMap.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameMap.kt
@@ -56,6 +56,7 @@ fun GameMap(
     camera: CameraState,
     onCellTapped: (tapX: Float, tapY: Float, pixelToCell: (Float, Float) -> Pair<Int, Int>?) -> Unit,
     darkenedCells: Set<Pair<Int, Int>> = emptySet(),
+    highlightedCells: Set<Pair<Int, Int>> = emptySet(),
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -90,6 +91,7 @@ fun GameMap(
                     fields = fields,
                     players = players,
                     darkenedCells = darkenedCells,
+                    highlightedCells = highlightedCells,
                     modifier = Modifier.wrapContentSize()
                 )
             }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavController
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
-import at.aau.serg.websocketbrokerdemo.grid.HexGridLogic
 import at.aau.serg.websocketbrokerdemo.grid.MapLayouts
 import at.aau.serg.websocketbrokerdemo.network.ConnectionState
 import at.aau.serg.websocketbrokerdemo.network.GameSession
@@ -82,16 +81,17 @@ fun GameScreen(
     val connectionState by session.connectionState.collectAsStateWithLifecycle()
     val disconnectedNames = GameScreenLogic.disconnectedOtherPlayerNames(players, localName)
 
-    // Wenn eine eigene Einheit selektiert ist, dunkle alle Felder ab,
-    // die NICHT in Reichweite sind. Range = 2 nur wenn die Einheit auf
-    // einem eigenen (Field.owner == player) Feld steht, sonst 1.
-    val darkenedCells: Set<Pair<Int, Int>> = uiState.selected?.let { selected ->
-        val reachable = GameScreenLogic.reachableCells(selected, fields, layout)
-        if (reachable.isEmpty()) emptySet()
-        else HexGridLogic.allCells(layout).toSet() -
-            reachable -
-            setOf(selected.x to selected.y)
-    } ?: emptySet()
+    // Feld-Hervorhebung (gueltige Felder leuchten auf, der Rest wird
+    // abgedunkelt) wird vollstaendig in der reinen Logik berechnet -- der
+    // Composable reicht nur den State rein und das Ergebnis ans Rendering.
+    val highlighting = GameScreenLogic.cellHighlighting(
+        placementMode = uiState.placementMode,
+        selected = uiState.selected,
+        fields = fields,
+        units = units,
+        localName = localName,
+        layout = layout
+    )
 
     LaunchedEffect(status, gameState?.players) {
         val state = gameState ?: return@LaunchedEffect
@@ -134,7 +134,8 @@ fun GameScreen(
                     viewModel.onCellTapped(cell.first, cell.second, units)
                 }
             },
-            darkenedCells = darkenedCells
+            darkenedCells = highlighting.darkened,
+            highlightedCells = highlighting.highlighted
         )
 
         TopHud(

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogic.kt
@@ -185,4 +185,100 @@ object GameScreenLogic {
             }
             .toSet()
     }
+
+    /**
+     * Berechnet die Felder, auf denen der Spieler eine gekaufte Einheit
+     * platzieren darf (Platzierungs-Modus).
+     *
+     * Spiegelt exakt die Server-Validierung in buyUnit wider:
+     *  - Feld gehoert dem Spieler (owner == [localName])
+     *  - Feld ist NICHT abgeschnitten (isSkeleton == false)
+     *  - Feld ist NICHT von einer eigenen Einheit besetzt -- inklusive der
+     *    eigenen BASE/Hauptburg. Eigene Skelett-Reste zaehlen NICHT als
+     *    besetzt, weil der Server sie beim Platzieren entfernt.
+     *
+     * Feindliche Einheiten/Felder werden gar nicht erst betrachtet, da nur
+     * eigene Felder ueberhaupt in Frage kommen. Liefert eine leere Menge,
+     * wenn [localName] null ist.
+     */
+    fun placeableCells(
+        fields: List<Field>,
+        units: List<GameUnit>,
+        localName: String?
+    ): Set<Pair<Int, Int>> {
+        if (localName == null) return emptySet()
+        val occupiedByOwn = units
+            .asSequence()
+            .filter { it.player == localName && it.type != UnitType.SKELETON }
+            .map { it.x to it.y }
+            .toSet()
+        return fields
+            .asSequence()
+            .filter { it.owner == localName && !it.isSkeleton }
+            .map { it.x to it.y }
+            .filter { it !in occupiedByOwn }
+            .toSet()
+    }
+
+    /**
+     * Ergebnis der Feld-Hervorhebung auf der Karte: welche Zellen aktiv
+     * aufleuchten (gueltige Ziele) und welche abgedunkelt werden (ungueltig
+     * bzw. ausserhalb der Reichweite).
+     */
+    data class CellHighlight(
+        val highlighted: Set<Pair<Int, Int>>,
+        val darkened: Set<Pair<Int, Int>>
+    )
+
+    /**
+     * Bestimmt die Feld-Hervorhebung fuer den aktuellen Interaktions-Modus.
+     *
+     *  - Platzierungs-Modus ([placementMode] != null): hervorgehoben sind die
+     *    eigenen, freien Felder ([placeableCells]).
+     *  - Bewegungs-Modus ([selected] != null): hervorgehoben sind die per
+     *    Reichweite erreichbaren Felder ([reachableCells]) ABZUEGLICH der
+     *    Felder, die von einer eigenen Einheit (Truppe ODER Hauptburg)
+     *    besetzt sind -- dorthin laesst der Server keinen Zug zu, also werden
+     *    sie nicht hervorgehoben, sondern abgedunkelt.
+     *  - Kein Modus aktiv: nichts hervorgehoben, nichts abgedunkelt.
+     *
+     * Abgedunkelt wird jeweils alles ausser den hervorgehobenen Feldern und
+     * (im Bewegungs-Modus) dem Standfeld der selektierten Einheit. Ist nichts
+     * hervorgehoben, bleibt auch nichts abgedunkelt.
+     */
+    fun cellHighlighting(
+        placementMode: UnitType?,
+        selected: GameUnit?,
+        fields: List<Field>,
+        units: List<GameUnit>,
+        localName: String?,
+        layout: MapLayout
+    ): CellHighlight {
+        val highlighted: Set<Pair<Int, Int>> = when {
+            placementMode != null -> placeableCells(fields, units, localName)
+            selected != null ->
+                reachableCells(selected, fields, layout) - ownOccupiedCells(units, selected.player)
+            else -> emptySet()
+        }
+        if (highlighted.isEmpty()) return CellHighlight(emptySet(), emptySet())
+
+        val allCells = HexGridLogic.allCells(layout).toSet()
+        val ownStand = setOfNotNull(selected?.let { it.x to it.y })
+        return CellHighlight(
+            highlighted = highlighted,
+            darkened = allCells - highlighted - ownStand
+        )
+    }
+
+    /**
+     * Zellen, die von einer Einheit des Spielers [player] besetzt sind --
+     * inklusive Hauptburg (BASE) und eigener Skelett-Reste. Spiegelt die
+     * "friendlyOnTarget"-Pruefung des Servers wider, die einen Zug auf ein
+     * von eigenen Einheiten besetztes Feld ablehnt.
+     */
+    private fun ownOccupiedCells(units: List<GameUnit>, player: String): Set<Pair<Int, Int>> =
+        units.asSequence()
+            .filter { it.player == player }
+            .map { it.x to it.y }
+            .toSet()
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogic.kt
@@ -271,14 +271,15 @@ object GameScreenLogic {
     }
 
     /**
-     * Zellen, die von einer Einheit des Spielers [player] besetzt sind --
-     * inklusive Hauptburg (BASE) und eigener Skelett-Reste. Spiegelt die
-     * "friendlyOnTarget"-Pruefung des Servers wider, die einen Zug auf ein
-     * von eigenen Einheiten besetztes Feld ablehnt.
+     * Zellen, die von einer eigenen, "lebenden" Einheit des Spielers [player]
+     * besetzt sind -- inklusive Hauptburg (BASE), ABER ohne Skelett-Reste:
+     * auf ein eigenes Skelett darf man ziehen, um es einzunehmen (der Server
+     * entfernt das Skelett beim Betreten des Feldes). Solche Felder blockieren
+     * die Bewegung also nicht und werden daher NICHT abgedunkelt.
      */
     private fun ownOccupiedCells(units: List<GameUnit>, player: String): Set<Pair<Int, Int>> =
         units.asSequence()
-            .filter { it.player == player }
+            .filter { it.player == player && it.type != UnitType.SKELETON }
             .map { it.x to it.y }
             .toSet()
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/components/UnitCoinButton.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/components/UnitCoinButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,6 +23,7 @@ import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
 import at.aau.serg.websocketbrokerdemo.data.serverside.UnitType
 import at.aau.serg.websocketbrokerdemo.grid.UnitIconProvider
 import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinDark
+import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinLight
 import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
 import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentDark
 
@@ -48,6 +50,17 @@ fun UnitCoinButton(
         modifier = modifier
             .size(50.dp)
             .alpha(if (enabled) 1f else 0.4f)
+            // Im Platzierungs-Modus (Muenze ausgewaehlt) goldener Ring +
+            // dezenter Glow, damit klar ist welche Truppe gerade gesetzt wird.
+            .then(
+                if (selected) {
+                    Modifier
+                        .background(GoldCoinDark.copy(alpha = 0.35f), CircleShape)
+                        .border(3.dp, GoldCoinLight, CircleShape)
+                } else {
+                    Modifier
+                }
+            )
             .clickable(enabled = enabled, onClick = onClick)
     ) {
         // Icon

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogicTest.kt
@@ -407,4 +407,141 @@ class GameScreenLogicTest {
         val result = GameScreenLogic.disconnectedOtherPlayerNames(players, null)
         assertEquals(listOf(alice, bob), result)
     }
+
+    // ---- placeableCells ----------------------------------------------
+
+    @Test
+    fun `placeableCells liefert nur eigene freie Felder`() {
+        val fields = listOf(
+            field(1, 1, alice),
+            field(2, 2, alice),
+            field(3, 3, null),
+            field(4, 4, bob)
+        )
+        val result = GameScreenLogic.placeableCells(fields, emptyList(), alice)
+        assertEquals(setOf(1 to 1, 2 to 2), result)
+    }
+
+    @Test
+    fun `placeableCells schliesst von eigener Truppe besetzte Felder aus`() {
+        val fields = listOf(field(1, 1, alice), field(2, 2, alice))
+        val units = listOf(ownInf(2, 2))
+        val result = GameScreenLogic.placeableCells(fields, units, alice)
+        assertEquals(setOf(1 to 1), result)
+    }
+
+    @Test
+    fun `placeableCells schliesst die eigene BASE aus`() {
+        val fields = listOf(field(2, 2, alice))
+        val units = listOf(GameUnit(player = alice, x = 2, y = 2, type = UnitType.BASE))
+        val result = GameScreenLogic.placeableCells(fields, units, alice)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `placeableCells schliesst Skelett-Felder aus`() {
+        val fields = listOf(
+            field(1, 1, alice),
+            Field(x = 2, y = 2, owner = alice, isSkeleton = true)
+        )
+        val result = GameScreenLogic.placeableCells(fields, emptyList(), alice)
+        assertEquals(setOf(1 to 1), result)
+    }
+
+    @Test
+    fun `placeableCells wertet eigenes Skelett-Feld als frei`() {
+        // Eigene Skelett-Reste werden beim Platzieren entfernt -> Feld bleibt frei.
+        val fields = listOf(field(1, 1, alice))
+        val units = listOf(GameUnit(player = alice, x = 1, y = 1, type = UnitType.SKELETON))
+        val result = GameScreenLogic.placeableCells(fields, units, alice)
+        assertEquals(setOf(1 to 1), result)
+    }
+
+    @Test
+    fun `placeableCells leer wenn localName null`() {
+        val fields = listOf(field(1, 1, alice))
+        val result = GameScreenLogic.placeableCells(fields, emptyList(), null)
+        assertTrue(result.isEmpty())
+    }
+
+    // ---- cellHighlighting --------------------------------------------
+
+    @Test
+    fun `cellHighlighting im Placement-Modus hebt eigene freie Felder hervor`() {
+        val fields = listOf(field(1, 1, alice), field(2, 2, alice))
+        val units = listOf(ownInf(2, 2)) // (2,2) besetzt -> nicht platzierbar
+        val result = GameScreenLogic.cellHighlighting(
+            placementMode = UnitType.INFANTRY,
+            selected = null,
+            fields = fields,
+            units = units,
+            localName = alice,
+            layout = testLayout
+        )
+        assertEquals(setOf(1 to 1), result.highlighted)
+        assertTrue((1 to 1) !in result.darkened)
+        assertTrue((2 to 2) in result.darkened) // eigenes, aber besetztes Feld abgedunkelt
+    }
+
+    @Test
+    fun `cellHighlighting im Bewegungs-Modus dunkelt von eigener Truppe blockierte Felder ab`() {
+        val mover = ownInf(3, 3)
+        val blocked = 3 to 2 // dist-1 Nachbar, von eigener Truppe besetzt
+        val units = listOf(mover, ownInf(blocked.first, blocked.second))
+        val result = GameScreenLogic.cellHighlighting(
+            placementMode = null,
+            selected = mover,
+            fields = emptyList(),
+            units = units,
+            localName = alice,
+            layout = testLayout
+        )
+        assertTrue(blocked !in result.highlighted) // blockiert -> nicht hervorgehoben
+        assertTrue(blocked in result.darkened)      // blockiert -> abgedunkelt
+    }
+
+    @Test
+    fun `cellHighlighting im Bewegungs-Modus blockiert die eigene Hauptburg`() {
+        val mover = ownInf(3, 3)
+        val baseCell = 3 to 2
+        val units = listOf(
+            mover,
+            GameUnit(player = alice, x = baseCell.first, y = baseCell.second, type = UnitType.BASE)
+        )
+        val result = GameScreenLogic.cellHighlighting(
+            null, mover, emptyList(), units, alice, testLayout
+        )
+        assertTrue(baseCell !in result.highlighted)
+        assertTrue(baseCell in result.darkened)
+    }
+
+    @Test
+    fun `cellHighlighting im Bewegungs-Modus haelt feindlich besetzte Felder als Ziel`() {
+        val mover = ownInf(3, 3)
+        val enemyCell = 3 to 2 // dist-1 Nachbar, Gegner drauf -> Angriff erlaubt
+        val units = listOf(mover, enemyArc(enemyCell.first, enemyCell.second))
+        val result = GameScreenLogic.cellHighlighting(
+            null, mover, emptyList(), units, alice, testLayout
+        )
+        assertTrue(enemyCell in result.highlighted)
+    }
+
+    @Test
+    fun `cellHighlighting dunkelt das Standfeld der selektierten Einheit nicht ab`() {
+        val mover = ownInf(3, 3)
+        val result = GameScreenLogic.cellHighlighting(
+            null, mover, emptyList(), listOf(mover), alice, testLayout
+        )
+        assertTrue((3 to 3) !in result.darkened)
+        assertTrue((3 to 3) !in result.highlighted)
+    }
+
+    @Test
+    fun `cellHighlighting ohne Modus hebt nichts hervor und dunkelt nichts ab`() {
+        val result = GameScreenLogic.cellHighlighting(
+            null, null, emptyList(), emptyList(), alice, testLayout
+        )
+        assertTrue(result.highlighted.isEmpty())
+        assertTrue(result.darkened.isEmpty())
+    }
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreenLogicTest.kt
@@ -516,6 +516,21 @@ class GameScreenLogicTest {
     }
 
     @Test
+    fun `cellHighlighting im Bewegungs-Modus blockiert eigene Skelette NICHT (einnehmbar)`() {
+        val mover = ownInf(3, 3)
+        val skeletonCell = 3 to 2 // dist-1 Nachbar, eigenes Skelett -> einnehmbar
+        val units = listOf(
+            mover,
+            GameUnit(player = alice, x = skeletonCell.first, y = skeletonCell.second, type = UnitType.SKELETON)
+        )
+        val result = GameScreenLogic.cellHighlighting(
+            null, mover, emptyList(), units, alice, testLayout
+        )
+        assertTrue(skeletonCell in result.highlighted) // Skelett blockiert nicht
+        assertTrue(skeletonCell !in result.darkened)
+    }
+
+    @Test
     fun `cellHighlighting im Bewegungs-Modus haelt feindlich besetzte Felder als Ziel`() {
         val mover = ownInf(3, 3)
         val enemyCell = 3 to 2 // dist-1 Nachbar, Gegner drauf -> Angriff erlaubt


### PR DESCRIPTION
## Summary

Makes it visually clear where a player can act. Tapping a troop coin or
selecting a unit now lights up the valid target cells (subtle brighten +
gold border) and darkens the rest. Dark player colours (e.g. blue) were
previously hard to read on the board.

## Changes

- **Placement mode:** highlights own free fields — owned, not skeleton,
  not occupied by an own troop or the base. Mirrors the server's
  `buyUnit` validation.
- **Movement mode:** highlights reachable cells minus those blocked by
  own units (troops **and** the main base). Enemy-occupied cells stay
  highlighted as attack targets — mirrors the server's
  `friendlyOnTarget` rejection.
- **Selected coin:** `UnitCoinButton` now renders a gold ring + glow for
  the active troop (the `selected` flag existed but was unused).

## Code hygiene

- All highlight/darken decision logic lives in the pure, Compose-free
  `GameScreenLogic.cellHighlighting()` — none of it in the `GameScreen`
  Composable.
- Result type `CellHighlight` is nested in the existing `GameScreenLogic`
  (like `TapAction`) — no new files / fragmentation.
- KDocs on the new function, data class and helper; intent-revealing
  names.

## Tests

- 6 new `GameScreenLogicTest` cases for `cellHighlighting` (placement
  highlight, own-troop block, base block, enemy stays a target, selected
  cell stays neutral, no-mode) plus the earlier `placeableCells` cases.
- `./gradlew :app:testDebugUnitTest` passes.