### PR TITLE
Add release CI: publish APK to GitHub Releases and Itch.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
       ITCH_TARGET: hexabrawl/hexabrawl:android
       APK_PATH: app/build/outputs/apk/debug/app-debug.apk
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'zulu'
@@ -37,7 +37,15 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build debug APK
-        run: ./gradlew :app:assembleDebug --no-daemon
+        # Bei einem Tag-Release: versionName aus dem Tag (ohne fuehrendes "v"),
+        # sonst Default "1.0". versionCode = monoton steigende Run-Nummer
+        # (Android verlangt einen aufsteigenden Integer).
+        env:
+          VERSION_NAME: ${{ github.ref_type == 'tag' && github.ref_name || '1.0' }}
+        run: |
+          ./gradlew :app:assembleDebug --no-daemon \
+            -PversionName="${VERSION_NAME#v}" \
+            -PversionCode="${{ github.run_number }}"
 
       - name: Publish APK to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+# Baut bei einem Versions-Tag (v*) eine downloadbare APK und veroeffentlicht
+# sie an zwei Stellen: als GitHub-Release-Asset und auf Itch.io (via butler).
+# Manuell per "Run workflow" (workflow_dispatch) ohne Tag moeglich -- dann wird
+# nur nach Itch.io gepusht (ein GitHub-Release braucht einen Tag).
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Build APK and publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # noetig, damit action-gh-release das Release anlegen darf
+    env:
+      # Itch.io-Ziel im Format <user>/<spiel>:<channel>.
+      # <spiel> = der Teil hinter hexabrawl.itch.io/... ; anpassen falls die
+      # Projekt-Seite anders heisst. Die Projekt-Seite MUSS auf itch.io
+      # existieren (Kind: Android), sonst lehnt butler den Push ab.
+      ITCH_TARGET: hexabrawl/hexabrawl:android
+      APK_PATH: app/build/outputs/apk/debug/app-debug.apk
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build debug APK
+        run: ./gradlew :app:assembleDebug --no-daemon
+
+      - name: Publish APK to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.APK_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install butler
+        run: |
+          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          unzip butler.zip
+          chmod +x butler
+          ./butler -V
+
+      - name: Push APK to Itch.io
+        env:
+          BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+        run: ./butler push "${{ env.APK_PATH }}" "${{ env.ITCH_TARGET }}" --userversion "${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Publish APK to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: ${{ env.APK_PATH }}
         env:
@@ -49,7 +49,9 @@ jobs:
 
       - name: Install butler
         run: |
-          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          # --proto '=https' erzwingt HTTPS auch ueber Redirects (kein Fallback
+          # auf http); -sSf macht Fehler sichtbar und bricht bei HTTP-Fehlern ab.
+          curl --proto '=https' --tlsv1.2 -sSfL -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
           unzip butler.zip
           chmod +x butler
           ./butler -V

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,11 @@ android {
         applicationId = "com.example.myapplication"
         minSdk = 30
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        // Aus dem Release-Tag ableitbar: die CI uebergibt -PversionName /
+        // -PversionCode (siehe .github/workflows/release.yml). Lokale Builds
+        // ohne diese Properties fallen auf die Defaults zurueck.
+        versionCode = (project.findProperty("versionCode") as String?)?.toInt() ?: 1
+        versionName = (project.findProperty("versionName") as String?) ?: "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION

## Summary

Finalisiert die App für die Abgabe: fügt automatisiertes APK-Publishing hinzu

## Release Management 

- **`.github/workflows/release.yml`**: baut bei einem `v*`-Tag (oder
  manuell via *Run workflow*) die Debug-APK, hängt sie als Asset an das
  **GitHub Release** und pusht sie via **butler** nach **Itch.io**
  (`hexabrawl/hexabrawl:android`).
- Voraussetzungen: Repo-Secret `BUTLER_API_KEY` (gesetzt) und die
  Itch.io-Projektseite (Kind: Android).
- Auslösen: `git tag v1.0.0 && git push origin v1.0.0`.


### Address two SonarQube findings in release.yml:

- Pin softprops/action-gh-release to the immutable commit SHA
  (3bb12739…, = v2.6.2) instead of the movable @v2 tag.
- Add --proto '=https' --tlsv1.2 -sSf to the butler download so redirects
  can't downgrade to an insecure protocol and HTTP errors fail the step.