### PR TITLE
Lobby mode validate

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogic.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
 
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameMode
 import at.aau.serg.websocketbrokerdemo.data.serverside.RoomDTO
 
 /**
@@ -30,18 +31,33 @@ object LobbyRoomLogic {
             listOf(LobbyEffect.ShowError("Raum konnte nicht erstellt werden"))
         }
 
-    /** Effekte fuer das Ergebnis eines findByCode-Aufrufs. */
-    fun effectsForJoinByCodeResult(room: RoomDTO?, code: String): List<LobbyEffect> =
-        if (room != null && room.roomId.isNotBlank()) {
-            listOf(
-                LobbyEffect.SetRoomId(room.roomId),
-                LobbyEffect.SetJoinCode(room.joinCode),
-                LobbyEffect.CloseJoinDialog,
-                LobbyEffect.NavigateToWaiting,
-            )
-        } else {
+    /**
+     * Effekte fuer das Ergebnis eines findByCode-Aufrufs.
+     *
+     * Schlaegt fehl, wenn kein Raum gefunden wurde ODER der gefundene Raum
+     * einen anderen [GameMode] hat als der, aus dem der User beitreten will
+     * ([expectedMode]) -- sonst landet er in einem fremden Spielmodus.
+     */
+    fun effectsForJoinByCodeResult(
+        room: RoomDTO?,
+        code: String,
+        expectedMode: GameMode
+    ): List<LobbyEffect> = when {
+        room == null || room.roomId.isBlank() ->
             listOf(LobbyEffect.ShowError("Kein Raum mit Code '$code' gefunden"))
-        }
+        room.mode != expectedMode ->
+            listOf(
+                LobbyEffect.ShowError(
+                    "Dieser Code gehört zu einem ${room.mode}-Raum, du wolltest einen $expectedMode-Raum."
+                )
+            )
+        else -> listOf(
+            LobbyEffect.SetRoomId(room.roomId),
+            LobbyEffect.SetJoinCode(room.joinCode),
+            LobbyEffect.CloseJoinDialog,
+            LobbyEffect.NavigateToWaiting,
+        )
+    }
 
     /**
      * Prueft, ob ein Join-Versuch ueberhaupt gestartet werden darf.

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyScreen.kt
@@ -185,7 +185,7 @@ fun LobbyScreen(
                         onCodeChange = { viewModel.onCodeChange(it) },
                         onDismiss = { viewModel.closeJoinDialog() },
                         onJoin = {
-                            viewModel.tryJoinByCodeAsync {
+                            viewModel.tryJoinByCodeAsync(mode) {
                                 navController.navigate(waitingScreen.route)
                             }
                         }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModel.kt
@@ -74,7 +74,7 @@ class LobbyViewModel(
     }
 
     /** Versucht via Code einem Raum beizutreten. */
-    fun tryJoinByCodeAsync(onSuccess: () -> Unit) {
+    fun tryJoinByCodeAsync(expectedMode: GameMode, onSuccess: () -> Unit) {
         if (!LobbyRoomLogic.canAttemptJoin(_state.value) || _isLoading.value) return
         val code = _state.value.code
 
@@ -83,7 +83,14 @@ class LobbyViewModel(
             _lastError.value = null
             try {
                 val room = apiClient.findByCode(code)
-                apply(LobbyRoomLogic.effectsForJoinByCodeResult(room, code), onSuccess)
+                apply(
+                    LobbyRoomLogic.effectsForJoinByCodeResult(
+                        room,
+                        code,
+                        mapUiToDataMode(expectedMode)
+                    ),
+                    onSuccess
+                )
             } catch (e: Exception) {
                 _isLoading.value = false
                 _lastError.value = "Netzwerkfehler: ${e.message}"

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyRoomLogicTest.kt
@@ -54,7 +54,7 @@ class LobbyRoomLogicTest {
             joinCode = "ROOM45",
             mode = GameMode.DUAL_VALLEY
         )
-        val effects = LobbyRoomLogic.effectsForJoinByCodeResult(room, "123456")
+        val effects = LobbyRoomLogic.effectsForJoinByCodeResult(room, "123456", GameMode.DUAL_VALLEY)
 
         assertEquals(4, effects.size)
         assertTrue(effects.any { it is LobbyEffect.SetRoomId && it.roomId == "uuid-join" })
@@ -64,9 +64,24 @@ class LobbyRoomLogicTest {
     }
 
     @Test
+    fun `effectsForJoinByCodeResult returns error when room mode differs from expected`() {
+        val room = RoomDTO(
+            roomId = "uuid-join",
+            joinCode = "ROOM45",
+            mode = GameMode.TRIAD_OUTPOST
+        )
+        val effects = LobbyRoomLogic.effectsForJoinByCodeResult(room, "123456", GameMode.DUAL_VALLEY)
+
+        assertEquals(1, effects.size)
+        val effect = effects[0] as LobbyEffect.ShowError
+        assertTrue(effect.message.contains("TRIAD_OUTPOST"))
+        assertTrue(effect.message.contains("DUAL_VALLEY"))
+    }
+
+    @Test
     fun `effectsForJoinByCodeResult returns error including code when join fails`() {
         // Case 1: room is null
-        val effectsNull = LobbyRoomLogic.effectsForJoinByCodeResult(null, "ABCDEF")
+        val effectsNull = LobbyRoomLogic.effectsForJoinByCodeResult(null, "ABCDEF", GameMode.DUAL_VALLEY)
         assertEquals(1, effectsNull.size)
         assertTrue((effectsNull[0] as LobbyEffect.ShowError).message.contains("ABCDEF"))
 
@@ -76,7 +91,7 @@ class LobbyRoomLogicTest {
             joinCode = "JOIN42",
             mode = GameMode.DUAL_VALLEY
         )
-        val effectsBlank = LobbyRoomLogic.effectsForJoinByCodeResult(roomBlank, "EFGHIJ")
+        val effectsBlank = LobbyRoomLogic.effectsForJoinByCodeResult(roomBlank, "EFGHIJ", GameMode.DUAL_VALLEY)
         assertEquals(1, effectsBlank.size)
         assertTrue((effectsBlank[0] as LobbyEffect.ShowError).message.contains("EFGHIJ"))
     }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/lobby_modes/LobbyViewModelTest.kt
@@ -3,6 +3,7 @@ package at.aau.serg.websocketbrokerdemo.ui.lobby_modes
 import androidx.compose.runtime.mutableStateOf
 import at.aau.serg.websocketbrokerdemo.data.serverside.GameMode
 import at.aau.serg.websocketbrokerdemo.data.serverside.RoomDTO
+import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode as UiGameMode
 import at.aau.serg.websocketbrokerdemo.network.GameSession
 import at.aau.serg.websocketbrokerdemo.network.RoomApiClient
 import io.mockk.coEvery
@@ -138,7 +139,7 @@ class LobbyViewModelTest {
         coEvery { apiClient.findByCode("CODE12") } returns room
         var successCalled = false
 
-        vm.tryJoinByCodeAsync {
+        vm.tryJoinByCodeAsync(UiGameMode.DUAL_VALLEY) {
             successCalled = true
         }
 
@@ -155,7 +156,7 @@ class LobbyViewModelTest {
         vm.onCodeChange("CODE12")
         coEvery { apiClient.findByCode("CODE12") } returns null
 
-        vm.tryJoinByCodeAsync {}
+        vm.tryJoinByCodeAsync(UiGameMode.DUAL_VALLEY) {}
 
         assertTrue(vm.state.value.showJoinDialog)
         assertTrue(vm.lastError.value!!.contains("CODE12"))


### PR DESCRIPTION
effectsForJoinByCodeResult now takes the expected GameMode and returns a
ShowError when the looked-up room's mode doesn't match, so a code for a
TRIAD/BATTLEFIELD room can no longer pull you into the wrong mode. The
expected mode is threaded through tryJoinByCodeAsync (converted via
mapUiToDataMode) and the LobbyScreen call site. Tests updated for the new
signature plus a mode-mismatch case.