### PR TITLE
Game resync fix

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -12,6 +12,7 @@ import at.aau.serg.websocketbrokerdemo.data.LanguageCache
 import at.aau.serg.websocketbrokerdemo.data.LanguageHelper
 import at.aau.serg.websocketbrokerdemo.data.SettingsRepository
 import at.aau.serg.websocketbrokerdemo.data.settingsDataStore
+import at.aau.serg.websocketbrokerdemo.network.ConnectionState
 import at.aau.serg.websocketbrokerdemo.network.GameSession
 import at.aau.serg.websocketbrokerdemo.network.Stomp
 import at.aau.serg.websocketbrokerdemo.network.UnitMoveEndpoint
@@ -38,7 +39,11 @@ class MainActivity : ComponentActivity() {
 
     private val stomp = Stomp()
     private val endpoint = UnitMoveEndpoint(stomp)
-    private val session = GameSession(endpoint, connectionState = stomp.connectionState)
+    private val session = GameSession(
+        endpoint,
+        connectionState = stomp.connectionState,
+        onRetryConnect = stomp::retryConnect
+    )
 
     override fun attachBaseContext(newBase: Context) {
         val lang = LanguageCache.get(newBase)
@@ -107,6 +112,15 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         MusicManager.resume()
+        // Nach laengerer Pause (Hintergrund laenger als das 30s-Reconnect-
+        // Fenster) kann die Verbindung endgueltig verloren sein. Beim
+        // Zurueckkehren erneut verbinden, sofern ein Match laeuft --
+        // retryConnect ist ein No-op, wenn die Verbindung ohnehin steht.
+        if (!session.sessionRepository.roomId.isNullOrBlank() &&
+            stomp.connectionState.value != ConnectionState.Connected
+        ) {
+            stomp.retryConnect()
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/GameSession.kt
@@ -50,5 +50,11 @@ class GameSession(
     val localPlayerName: MutableState<String?> = mutableStateOf(null),
     val sessionRepository: SessionRepository = SessionRepository(),
     val connectionState: StateFlow<ConnectionState> =
-        MutableStateFlow(ConnectionState.Connected).asStateFlow()
+        MutableStateFlow(ConnectionState.Connected).asStateFlow(),
+    /**
+     * Manueller Reconnect-Versuch (nach LostPermanently). Wird in der
+     * MainActivity an [at.aau.serg.websocketbrokerdemo.network.Stomp.retryConnect]
+     * gebunden; Default ist ein No-op fuer Previews/Tests.
+     */
+    val onRetryConnect: () -> Unit = {}
 )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/Stomp.kt
@@ -157,7 +157,11 @@ class Stomp(
         while (isActive && !intentionallyDisconnected) {
             runSubscription(topic, onMessage)
             if (intentionallyDisconnected) break
-            if (awaitConnectedOrLost() == ConnectionState.LostPermanently) break
+            // Auf die naechste stehende Verbindung warten und dann neu
+            // abonnieren -- bewusst OHNE Abbruch bei LostPermanently, damit ein
+            // spaeterer Reconnect (App-Resume / Retry-Button) die Subscription
+            // wiederbelebt. Parkt suspendiert (kein Busy-Loop).
+            awaitNextConnected()
         }
     }
 
@@ -187,14 +191,28 @@ class Stomp(
     }
 
     /**
-     * Suspendiert, bis der naechste stabile Verbindungszustand erreicht ist:
-     * [ConnectionState.Connected] (dann abonniert die Loop neu) oder
-     * [ConnectionState.LostPermanently] (dann gibt sie auf).
+     * Suspendiert, bis die Verbindung wieder steht ([ConnectionState.Connected]).
+     * Bewusst OHNE Abbruch bei [ConnectionState.LostPermanently], damit die
+     * Subscribe-Loop einen spaeteren manuellen Reconnect ([retryConnect]) oder
+     * App-Resume abwarten und dann neu abonnieren kann.
      */
-    private suspend fun awaitConnectedOrLost(): ConnectionState =
-        connectionState.first {
-            it == ConnectionState.Connected || it == ConnectionState.LostPermanently
-        }
+    private suspend fun awaitNextConnected() {
+        connectionState.first { it == ConnectionState.Connected }
+    }
+
+    /**
+     * Manueller Reconnect-Versuch, nachdem die Auto-Reconnect-Loop aufgegeben
+     * hat ([ConnectionState.LostPermanently]) -- genutzt vom "Erneut verbinden"-
+     * Button und vom App-Resume. Re-armt das intentionallyDisconnected-Flag und
+     * startet die Reconnect-Loop neu; bei Erfolg feuern die [onReconnected]-
+     * Callbacks und die Subscriptions abonnieren ueber [awaitNextConnected]
+     * von selbst neu. No-op, wenn bereits verbunden.
+     */
+    fun retryConnect() {
+        if (connectionState.value == ConnectionState.Connected) return
+        intentionallyDisconnected = false
+        handleSessionLost("manual retry")
+    }
 
     /**
      * Sendet einen rohen Text-Payload (content-type: text/plain).

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -26,6 +26,7 @@ import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.ReconnectingOve
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
 import androidx.compose.runtime.LaunchedEffect
 import at.aau.serg.websocketbrokerdemo.ui.navigation.Screen
+import kotlinx.coroutines.delay
 
 /**
  * GameScreen -- der eigentliche Spielbildschirm.
@@ -120,6 +121,24 @@ fun GameScreen(
         }
     }
 
+    // Resync nach (Re-)Connect: STOMP-Subscriptions liefern nur ZUKUENFTIGE
+    // Broadcasts -- waehrend einer Trennung verpasste Aenderungen (Zugwechsel,
+    // pendingGift, ...) fehlen sonst, der Client haengt oder zeigt kein Popup.
+    // Sobald die Verbindung steht und ein Match laeuft, fordern wir den
+    // aktuellen GameState gestaffelt an, bis ein frischer Broadcast eintrifft
+    // (analog zur Wartelobby).
+    LaunchedEffect(connectionState) {
+        if (connectionState != ConnectionState.Connected) return@LaunchedEffect
+        val roomId = session.activeRoomId.value
+        if (roomId.isBlank()) return@LaunchedEffect
+        val before = session.gameState.value
+        repeat(GAME_RESYNC_REQUESTS) {
+            session.endpoint.requestRoomState(roomId)
+            delay(GAME_RESYNC_DELAY_MS)
+            if (session.gameState.value !== before) return@LaunchedEffect
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         GameMap(
             layout = layout,
@@ -184,6 +203,7 @@ fun GameScreen(
         if (connectionState != ConnectionState.Connected) {
             ReconnectingOverlay(
                 state = connectionState,
+                onRetry = { session.onRetryConnect() },
                 onBackToMenu = {
                     session.sessionRepository.clear()
                     navController.navigate(Screen.Home.route) {
@@ -196,3 +216,9 @@ fun GameScreen(
         }
     }
 }
+
+/** Anzahl gestaffelter /init-Anfragen fuer den Resync nach (Re-)Connect. */
+private const val GAME_RESYNC_REQUESTS = 5
+
+/** Abstand zwischen zwei Resync-Anfragen in Millisekunden. */
+private const val GAME_RESYNC_DELAY_MS = 400L

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/ReconnectingOverlay.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/ReconnectingOverlay.kt
@@ -55,7 +55,8 @@ import com.example.myapplication.R
 @Composable
 fun ReconnectingOverlay(
     state: ConnectionState,
-    onBackToMenu: () -> Unit
+    onBackToMenu: () -> Unit,
+    onRetry: () -> Unit = {}
 ) {
     Box(
         modifier = Modifier
@@ -78,7 +79,7 @@ fun ReconnectingOverlay(
         ) {
             when (state) {
                 ConnectionState.Reconnecting -> ReconnectingBody()
-                ConnectionState.LostPermanently -> LostPermanentlyBody(onBackToMenu)
+                ConnectionState.LostPermanently -> LostPermanentlyBody(onRetry, onBackToMenu)
                 ConnectionState.Connected -> Unit
             }
         }
@@ -110,7 +111,7 @@ private fun ReconnectingBody() {
 }
 
 @Composable
-private fun LostPermanentlyBody(onBackToMenu: () -> Unit) {
+private fun LostPermanentlyBody(onRetry: () -> Unit, onBackToMenu: () -> Unit) {
     Text(
         text = stringResource(R.string.reconnect_lost_title),
         style = TextStyle(
@@ -130,6 +131,25 @@ private fun LostPermanentlyBody(onBackToMenu: () -> Unit) {
         )
     )
     Spacer(Modifier.height(24.dp))
+    Button(
+        onClick = onRetry,
+        shape = RoundedCornerShape(8.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = GoldCoinDark,
+            contentColor = ParchmentLight
+        )
+    ) {
+        Text(
+            text = stringResource(R.string.reconnect_retry),
+            style = TextStyle(
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = GoldCoinLight,
+                letterSpacing = 1.sp
+            )
+        )
+    }
+    Spacer(Modifier.height(12.dp))
     Button(
         onClick = onBackToMenu,
         shape = RoundedCornerShape(8.dp),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -122,6 +122,7 @@
     <string name="reconnect_lost_title">Verbindung verloren</string>
     <string name="reconnect_lost_subtitle">Der Server kann nicht erreicht werden.</string>
     <string name="reconnect_back_to_menu">Zurück zum Menü</string>
+    <string name="reconnect_retry">Erneut verbinden</string>
     <string name="disconnect_overlay_title">%1$s hat die Verbindung verloren</string>
     <string name="disconnect_overlay_subtitle">Warte auf Reconnect…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="reconnect_lost_title">Connection lost</string>
     <string name="reconnect_lost_subtitle">The server can\'t be reached.</string>
     <string name="reconnect_back_to_menu">Back to menu</string>
+    <string name="reconnect_retry">Try again</string>
     <string name="disconnect_overlay_title">%1$s lost connection</string>
     <string name="disconnect_overlay_subtitle">Waiting for reconnect…</string>
 </resources>


### PR DESCRIPTION
- subscribe() now waits for the next Connected state instead of breaking on
LostPermanently, so a topic re-subscribes whenever the connection returns.
Add retryConnect() to restart the reconnect loop after it gave up (used by
the app-resume hook and the retry button).

- ReconnectingOverlay's LostPermanently panel gets a retry action next to
"back to menu" (onRetry, default no-op so existing callers still compile).
Adds the reconnect_retry string (en + de).

- GameScreen re-requests the current GameState (staggered) whenever the
connection returns, catching up turn/pendingGift changes missed during a
drop -- fixes stuck state and missing popups. MainActivity retries the
connection on resume when a match is active, and GameSession exposes
onRetryConnect so the overlay's retry button triggers Stomp.retryConnect.