### PR TITLE
Reduce GameScreen cognitive complexity from 19 to ~8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,8 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         "**/ui/game/bottomhud/components/**",
         "**/ui/game/bottomhud/BottomHud.kt",
         "**/ui/game/GameScreen.kt",
+        "**/ui/game/GameOverNavigationEffect.kt",
+        "**/ui/game/GameStateResyncEffect.kt",
         "**/ui/game/GameMap.kt",
         "**/ui/game/camera/CameraModifier*.*",
         "**/ui/home/HomeScreen.kt",

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverNavigationEffect.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverNavigationEffect.kt
@@ -1,0 +1,53 @@
+package at.aau.serg.websocketbrokerdemo.ui.game
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.navigation.NavController
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameState
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
+import at.aau.serg.websocketbrokerdemo.network.GameSession
+import at.aau.serg.websocketbrokerdemo.ui.navigation.Screen
+
+/**
+ * Beobachtet den Spielzustand und navigiert beim Spielende auf den
+ * passenden EndScreen (Win / Loss).
+ *
+ * Wird vom [GameScreen] aufgerufen, kapselt aber die komplette
+ * Navigations-Logik -- dadurch bleibt GameScreen schlank und Sonar's
+ * Cognitive Complexity dort niedrig.
+ *
+ * Auslöser fürs Game-Over:
+ *  - GameStatus.FINISHED (klassisches Spielende, Sieger steht fest)
+ *  - Lokaler Spieler ist nicht mehr in state.players enthalten
+ *    (Eliminierung im 3-/4-Spieler-Modus; Server entfernt
+ *    Ausgeschiedene aus der Liste, siehe GameService.eliminatePlayer).
+ *
+ * Vor der Navigation wird die Reconnect-Identitaet via
+ * sessionRepository.clear() geloescht -- damit ein "App wegswipen"
+ * auf dem EndScreen kein /leave fuer einen toten Raum mehr ausloest.
+ */
+@Composable
+fun GameOverNavigationEffect(
+    gameState: GameState?,
+    status: GameStatus,
+    localName: String?,
+    session: GameSession,
+    navController: NavController
+) {
+    LaunchedEffect(status, gameState?.players) {
+        val state = gameState ?: return@LaunchedEffect
+        val name = localName ?: return@LaunchedEffect
+
+        val iAmEliminated = state.players.none { it.name == name }
+        val gameOver = status == GameStatus.FINISHED
+
+        if (iAmEliminated || gameOver) {
+            session.sessionRepository.clear()
+            val isWin = state.winner == name
+            val route = if (isWin) Screen.EndWin.route else Screen.EndLoss.route
+            navController.navigate(route) {
+                popUpTo(Screen.Home.route) { inclusive = false }
+            }
+        }
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt
@@ -24,9 +24,7 @@ import at.aau.serg.websocketbrokerdemo.ui.game.tophud.TopHud
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.DisconnectedPlayerOverlay
 import at.aau.serg.websocketbrokerdemo.ui.game.tophud.components.ReconnectingOverlay
 import at.aau.serg.websocketbrokerdemo.ui.mainmenu.GameMode
-import androidx.compose.runtime.LaunchedEffect
 import at.aau.serg.websocketbrokerdemo.ui.navigation.Screen
-import kotlinx.coroutines.delay
 
 /**
  * GameScreen -- der eigentliche Spielbildschirm.
@@ -94,50 +92,18 @@ fun GameScreen(
         layout = layout
     )
 
-    LaunchedEffect(status, gameState?.players) {
-        val state = gameState ?: return@LaunchedEffect
-        val name = localName ?: return@LaunchedEffect
+    GameOverNavigationEffect(
+        gameState = gameState,
+        status = status,
+        localName = localName,
+        session = session,
+        navController = navController
+    )
 
-        // Im 3-/4-Spieler-Modus bleibt der GameStatus nach dem Ausscheiden
-        // eines Spielers auf IN_PROGRESS — der Verlierer wird vom Server
-        // einfach aus state.players entfernt (siehe GameService.eliminatePlayer).
-        // Daher zusaetzlich pruefen, ob der lokale Spieler noch in der Liste
-        // steht; falls nicht, ist er raus und gehoert auf den LossScreen.
-        val iAmEliminated = state.players.none { it.name == name }
-        val gameOver = status == GameStatus.FINISHED
-
-        if (iAmEliminated || gameOver) {
-            // Spiel ist vorbei -- die Reconnect-Identitaet wird nicht
-            // mehr gebraucht. Wir loeschen sie hier (statt im EndScreen),
-            // damit ein direktes "App wegswipen" auf dem EndScreen kein
-            // /leave fuer einen toten Raum mehr ausloest.
-            session.sessionRepository.clear()
-            val isWin = state.winner == name
-            val route = if (isWin) Screen.EndWin.route else Screen.EndLoss.route
-            navController.navigate(route) {
-                // Clear the backstack up to Home to avoid going back into the finished game
-                popUpTo(Screen.Home.route) { inclusive = false }
-            }
-        }
-    }
-
-    // Resync nach (Re-)Connect: STOMP-Subscriptions liefern nur ZUKUENFTIGE
-    // Broadcasts -- waehrend einer Trennung verpasste Aenderungen (Zugwechsel,
-    // pendingGift, ...) fehlen sonst, der Client haengt oder zeigt kein Popup.
-    // Sobald die Verbindung steht und ein Match laeuft, fordern wir den
-    // aktuellen GameState gestaffelt an, bis ein frischer Broadcast eintrifft
-    // (analog zur Wartelobby).
-    LaunchedEffect(connectionState) {
-        if (connectionState != ConnectionState.Connected) return@LaunchedEffect
-        val roomId = session.activeRoomId.value
-        if (roomId.isBlank()) return@LaunchedEffect
-        val before = session.gameState.value
-        repeat(GAME_RESYNC_REQUESTS) {
-            session.endpoint.requestRoomState(roomId)
-            delay(GAME_RESYNC_DELAY_MS)
-            if (session.gameState.value !== before) return@LaunchedEffect
-        }
-    }
+    GameStateResyncEffect(
+        connectionState = connectionState,
+        session = session
+    )
 
     Box(modifier = Modifier.fillMaxSize()) {
         GameMap(
@@ -217,8 +183,3 @@ fun GameScreen(
     }
 }
 
-/** Anzahl gestaffelter /init-Anfragen fuer den Resync nach (Re-)Connect. */
-private const val GAME_RESYNC_REQUESTS = 5
-
-/** Abstand zwischen zwei Resync-Anfragen in Millisekunden. */
-private const val GAME_RESYNC_DELAY_MS = 400L

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameStateResyncEffect.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameStateResyncEffect.kt
@@ -1,0 +1,41 @@
+package at.aau.serg.websocketbrokerdemo.ui.game
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import at.aau.serg.websocketbrokerdemo.network.ConnectionState
+import at.aau.serg.websocketbrokerdemo.network.GameSession
+import kotlinx.coroutines.delay
+
+/**
+ * Resync nach (Re-)Connect.
+ *
+ * STOMP-Subscriptions liefern nur ZUKUENFTIGE Broadcasts -- waehrend
+ * einer Trennung verpasste Aenderungen (Zugwechsel, pendingGift, ...)
+ * fehlen sonst, der Client haengt oder zeigt kein Popup.
+ *
+ * Sobald die Verbindung steht und ein Match laeuft, wird der aktuelle
+ * GameState gestaffelt angefordert, bis ein frischer Broadcast eintrifft
+ * (analog zur Wartelobby). Sind alle Versuche aufgebraucht ohne neuen
+ * State, wird abgebrochen.
+ *
+ * Die Spielregel-Werte (Anzahl/Delay der Versuche) liegen in
+ * [GameStateResyncLogic], damit sie unabhaengig von der Composable
+ * testbar bleiben.
+ */
+@Composable
+fun GameStateResyncEffect(
+    connectionState: ConnectionState,
+    session: GameSession
+) {
+    LaunchedEffect(connectionState) {
+        if (connectionState != ConnectionState.Connected) return@LaunchedEffect
+        val roomId = session.activeRoomId.value
+        if (roomId.isBlank()) return@LaunchedEffect
+        val before = session.gameState.value
+        repeat(GameStateResyncLogic.RESYNC_REQUESTS) {
+            session.endpoint.requestRoomState(roomId)
+            delay(GameStateResyncLogic.RESYNC_DELAY_MS)
+            if (session.gameState.value !== before) return@LaunchedEffect
+        }
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameStateResyncLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameStateResyncLogic.kt
@@ -1,0 +1,22 @@
+package at.aau.serg.websocketbrokerdemo.ui.game
+
+/**
+ * Konstanten fuer den Resync-Mechanismus nach (Re-)Connect.
+ *
+ * Wird vom [GameStateResyncEffect] genutzt. Liegt in einer eigenen
+ * Datei, damit die Spielregel-Werte nicht in der Composable haengen
+ * und direkt JVM-testbar bleiben.
+ *
+ * Die Werte folgen dem Pattern der Wartelobby (siehe LobbyNetworkSync):
+ *  - mehrere gestaffelte /init-Anfragen, statt nur einer
+ *  - kurzer Delay dazwischen, damit der Server Zeit zum Broadcast hat
+ *  - Abbruch sobald ein frischer Broadcast eintrifft (von aussen)
+ */
+object GameStateResyncLogic {
+
+    /** Anzahl gestaffelter /init-Anfragen fuer den Resync nach (Re-)Connect. */
+    const val RESYNC_REQUESTS = 5
+
+    /** Abstand zwischen zwei Resync-Anfragen in Millisekunden. */
+    const val RESYNC_DELAY_MS = 400L
+}

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameStateResyncLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameStateResyncLogicTest.kt
@@ -1,0 +1,39 @@
+package at.aau.serg.websocketbrokerdemo.ui.game
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests fuer GameStateResyncLogic.
+ *
+ * Konstanten-Sanity: die Werte muessen positiv sein, sonst wuerde
+ * der Resync ueberhaupt nicht laufen (0 Requests) oder unbegrenzt
+ * im Block haengen (negativer Delay).
+ *
+ * Wert-Tests dokumentieren die aktuell gewaehlten Defaults; bei
+ * bewusster Aenderung des Resync-Verhaltens muessen die Tests
+ * mitgezogen werden.
+ */
+class GameStateResyncLogicTest {
+
+    @Test
+    fun `RESYNC_REQUESTS is positive`() {
+        assertTrue(GameStateResyncLogic.RESYNC_REQUESTS > 0)
+    }
+
+    @Test
+    fun `RESYNC_DELAY_MS is positive`() {
+        assertTrue(GameStateResyncLogic.RESYNC_DELAY_MS > 0L)
+    }
+
+    @Test
+    fun `RESYNC_REQUESTS matches expected default`() {
+        assertEquals(5, GameStateResyncLogic.RESYNC_REQUESTS)
+    }
+
+    @Test
+    fun `RESYNC_DELAY_MS matches expected default`() {
+        assertEquals(400L, GameStateResyncLogic.RESYNC_DELAY_MS)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,8 @@ sonar {
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/components/**",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/bottomhud/BottomHud.kt",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameScreen.kt",
+                "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverNavigationEffect.kt",
+                "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameStateResyncEffect.kt",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameMap.kt",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/camera/CameraModifier.kt",
                 "app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/home/HomeScreen.kt",


### PR DESCRIPTION
## Summary

Refactors `GameScreen.kt` to drop its Sonar cognitive complexity from 19
to ~8 (below threshold 15). Behavior unchanged.

## Was sich ändert

- **`GameStateResyncLogic`** (neu) — Object mit Resync-Konstanten, hat JVM-Tests
- **`GameOverNavigationEffect`** (neu) — kapselt das EndScreen-Navigation-LaunchedEffect
- **`GameStateResyncEffect`** (neu) — kapselt das Resync-LaunchedEffect
- **`GameScreen`** — beide LaunchedEffect-Blöcke raus, ~40 Zeilen kürzer
- Beide `*Effect.kt` Composables aus Sonar- und JaCoCo-Coverage ausgeschlossen

## How to test

- Spiel normal spielen + zu Ende bringen → EndScreen-Navigation funktioniert
- Netz kurz trennen + wieder verbinden → Reconnect läuft sauber
- Bestehende Tests bleiben grün