### PR TITLE
Resync button

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHud.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/TopHud.kt
@@ -107,6 +107,12 @@ fun TopHud(
         HudPopup.Menu -> HudMenuPopup(
             onSettings = viewModel::showSettings,
             onInfo = viewModel::showInfo,
+            onSync = {
+                // Aktuellen Server-State erzwingen (Resync), falls der Client
+                // durch einen verpassten Broadcast haengt.
+                session.endpoint.requestRoomState(session.activeRoomId.value)
+                viewModel.closePopup()
+            },
             onDismiss = viewModel::closePopup
         )
         HudPopup.Info -> InfoPopup(onDismiss = viewModel::closePopup)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/HudMenuPopup.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/tophud/components/HudMenuPopup.kt
@@ -31,14 +31,17 @@ import com.example.myapplication.R
 /**
  * Menue-Popup ueber dem Top-HUD.
  *
- * Bietet zwei Aktionen: zu den Einstellungen wechseln oder das Info-
- * Popup mit der Spielerklaerung oeffnen. Stateless -- alle Callbacks
- * kommen von aussen.
+ * Bietet drei Aktionen: zu den Einstellungen wechseln, das Info-Popup
+ * mit der Spielerklaerung oeffnen, oder den aktuellen Spielstand neu vom
+ * Server anfordern ([onSync]) -- nuetzlich, wenn der Client durch einen
+ * verpassten Broadcast haengt (z. B. ein Mitspieler ist weg, wird aber
+ * noch angezeigt). Stateless -- alle Callbacks kommen von aussen.
  */
 @Composable
 fun HudMenuPopup(
     onSettings: () -> Unit,
     onInfo: () -> Unit,
+    onSync: () -> Unit,
     onDismiss: () -> Unit
 ) {
     Dialog(onDismissRequest = onDismiss) {
@@ -86,6 +89,19 @@ fun HudMenuPopup(
                         text = stringResource(R.string.hud_menu_info),
                         primary = false,
                         onClick = onInfo
+                    )
+                }
+
+                Spacer(Modifier.height(10.dp))
+
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    DialogButton(
+                        text = stringResource(R.string.hud_menu_sync),
+                        primary = false,
+                        onClick = onSync
                     )
                 }
             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -73,6 +73,7 @@
     <string name="hud_menu_title">Menü</string>
     <string name="hud_menu_settings">Einstellungen</string>
     <string name="hud_menu_info">Informationen</string>
+    <string name="hud_menu_sync">Aktualisieren</string>
     <string name="hud_settings_title">Einstellungen</string>
     <string name="hud_info_title">Spielerklärung</string>
     <string name="hud_info_body">HexaBrawl ist ein rundenbasiertes Strategiespiel. Erobere Felder, baue Farmen und Truppen, und nimm die gegnerische Hauptburg ein, um zu gewinnen. Gold sammelst du über deine Farmen, und du kannst es ausgeben um Truppen zu kaufen.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="hud_menu_title">Menu</string>
     <string name="hud_menu_settings">Settings</string>
     <string name="hud_menu_info">Information</string>
+    <string name="hud_menu_sync">Refresh</string>
     <string name="hud_settings_title">Settings</string>
     <string name="hud_info_title">Game Rules</string>
     <string name="hud_info_body">HexaBrawl is a turn-based strategy game. Conquer tiles, build farms and units, and capture the enemy main castle to win. You earn gold from your farms and can spend it on troops.</string>


### PR DESCRIPTION
The HUD menu gets a "Refresh" entry that calls requestRoomState, making the
server rebroadcast the current GameState. Lets a player stuck on a stale
state (e.g. a player who left is still shown) pull the authoritative state
on demand, while connected -- without waiting for a disconnect.