### PR TITLE
Handle NAME_ALREADY_TAKEN error in the waiting lobby

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/ErrorCode.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/serverside/ErrorCode.kt
@@ -22,6 +22,9 @@ package at.aau.serg.websocketbrokerdemo.data.serverside
  *  - ROOM_NOT_FOUND       Der angegebene roomId existiert nicht (mehr) in
  *                         der RoomRegistry. Wird auch beim Join mit
  *                         falschem JoinCode bzw. UUID gesendet.
+ *  - NAME_ALREADY_TAKEN   Beitritt verweigert, weil der gewuenschte
+ *                         Spielername im Raum bereits von einem anderen
+ *                         (verbundenen) Spieler belegt ist.
  */
 enum class ErrorCode {
     NOT_YOUR_TURN,
@@ -30,5 +33,6 @@ enum class ErrorCode {
     GAME_NOT_STARTED,
     INSUFFICIENT_GOLD,
     COLOR_ALREADY_TAKEN,
-    ROOM_NOT_FOUND
+    ROOM_NOT_FOUND,
+    NAME_ALREADY_TAKEN
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
@@ -135,10 +135,10 @@ fun LobbyNetworkSync(
 
     // Server-Fehler beobachten und sinnvoll behandeln.
     //
-    // Speziell COLOR_ALREADY_TAKEN: der lokale Spieler hat eine Farbe
-    // gewaehlt, die schon belegt war. Wir setzen den ready-Status zurueck
-    // (damit der User die Farbe wieder wechseln kann) und zeigen eine
-    // Snackbar mit einem klaren Hinweis.
+    // COLOR_ALREADY_TAKEN / NAME_ALREADY_TAKEN: der lokale Spieler hat eine
+    // Farbe bzw. einen Namen gewaehlt, die/der schon belegt war. Wir setzen
+    // den ready-Status zurueck (damit Name/Farbe wieder editierbar sind) und
+    // zeigen eine Snackbar mit einem klaren Hinweis.
     //
     // Andere Fehler werden 1:1 als Snackbar gezeigt; die App bleibt
     // ansonsten im aktuellen State.
@@ -146,7 +146,7 @@ fun LobbyNetworkSync(
     LaunchedEffect(lastError) {
         val error = lastError ?: return@LaunchedEffect
         when (error.errorCode) {
-            ErrorCode.COLOR_ALREADY_TAKEN -> {
+            ErrorCode.COLOR_ALREADY_TAKEN, ErrorCode.NAME_ALREADY_TAKEN -> {
                 viewModel.clearLocalReady()
                 viewModel.showError(error.message)
             }


### PR DESCRIPTION
Add the NAME_ALREADY_TAKEN code to the client ErrorCode mirror and treat it
like COLOR_ALREADY_TAKEN in LobbyNetworkSync: reset ready so the player can
pick a different name, and surface the server message. Forward-compatible
-- inert until the server starts rejecting duplicate names.