### PR TITLE
Add missing KDoc to frontend composables and helpers

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/SettingsDataStoreProvider.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/data/SettingsDataStoreProvider.kt
@@ -5,4 +5,14 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 
+/**
+ * App-weiter Zugriff auf den Preferences-[DataStore] fuer Settings.
+ *
+ * Als Context-Extension definiert, sodass jede Komponente mit Context den
+ * Store ueber `context.settingsDataStore` erreicht. Der DataStore wird vom
+ * Delegate genau einmal pro Prozess unter dem Namen "hexabrawl_settings"
+ * angelegt; das [SettingsRepository] liest und schreibt darueber die
+ * persistenten Einstellungen (Sprache, Lautstaerken, ...).
+ */
+
 val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "hexabrawl_settings")

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/components/PlayerCountBadge.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/components/PlayerCountBadge.kt
@@ -20,6 +20,17 @@ import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinDark
 import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinLight
 import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
 
+/**
+ * Rundes Muenz-Badge, das die Spielerzahl als roemische Ziffer zeigt.
+ *
+ * Wandelt 2/3/4 in II/III/IV um (andere Werte werden als Dezimalzahl
+ * angezeigt) und stellt sie auf einem Gold-Medaillon dar. Wird in der
+ * Lobby genutzt, um den gewaehlten Spielmodus visuell zu kennzeichnen.
+ *
+ * @param count    Anzahl der Spieler des Modus.
+ * @param modifier Optionaler Layout-Modifier.
+ */
+
 @Composable
 public fun PlayerCountBadge(count: Int, modifier: Modifier = Modifier) {
     val roman = when (count) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/camera/CameraModifier.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/camera/CameraModifier.kt
@@ -5,6 +5,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 
+/**
+ * Modifier, der Pinch-Zoom und Pan auf die Spielkarte anwendet.
+ *
+ * Faengt Transform-Gesten ab und reicht sie an die seiteneffekt-freie
+ * [CameraGestureLogic] weiter: erst der neue Zoom, daraus der effektive
+ * Zoom-Faktor des Frames, dann die pivot-basierten Offsets (skaliert um den
+ * Gesten-Mittelpunkt statt um die Bildschirmmitte). Die Ergebnisse werden
+ * in den [camera]-State geschrieben und ueber [CameraState.clampOffset] auf
+ * den gueltigen Bereich begrenzt. Der `graphicsLayer`-Block uebertraegt
+ * Scale und Translation anschliessend auf die gerenderte Karte.
+ *
+ * @param camera Beobachtbarer Kamera-State (Zoom, Offset, Viewport).
+ */
+
 fun Modifier.cameraControls(camera: CameraState): Modifier =
     this
         .pointerInput(Unit) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/LanguageOptionButton.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/LanguageOptionButton.kt
@@ -18,6 +18,19 @@ import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
 import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentLight
 import at.aau.serg.websocketbrokerdemo.ui.theme.WoodMedium
 
+/**
+ * Auswahl-Button fuer eine einzelne Sprache im Settings-Screen.
+ *
+ * Der ausgewaehlte Zustand wird rein optisch gespiegelt (Gold-Fuellung,
+ * dickerer Rand, fetterer Text), damit der User die aktive Sprache auf
+ * einen Blick erkennt. Die eigentliche Auswahl-Logik liegt beim Aufrufer.
+ *
+ * @param text     Anzeigetext des Buttons (z. B. der Sprachname).
+ * @param selected Ob diese Sprache aktuell aktiv ist.
+ * @param onClick  Callback beim Antippen.
+ * @param modifier Optionaler Layout-Modifier.
+ */
+
 @Composable
 internal fun LanguageOptionButton(
     text: String,

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/SettingsBackButton.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/SettingsBackButton.kt
@@ -20,6 +20,16 @@ import at.aau.serg.websocketbrokerdemo.ui.theme.WoodDark
 import at.aau.serg.websocketbrokerdemo.ui.theme.WoodLight
 import com.example.myapplication.R
 
+/**
+ * Runder Zurueck-Button im Settings-Screen.
+ *
+ * Stilisiert als Holz-Medaillon mit Gold-Rand, passend zum Parchment-Theme
+ * des Spiels. Die contentDescription kommt aus den String-Resources, damit
+ * Screenreader den Button korrekt vorlesen.
+ *
+ * @param onClick Callback beim Antippen (typischerweise Navigation zurueck).
+ */
+
 @Composable
 internal fun SettingsBackButton(onClick: () -> Unit) {
     IconButton(

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/SettingsBackground.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/SettingsBackground.kt
@@ -16,6 +16,17 @@ import at.aau.serg.websocketbrokerdemo.ui.theme.GoldCoinDark
 import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentDark
 import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentLight
 
+/**
+ * Pergament-Karte als Hintergrund-Wrapper fuer Settings-Inhalte.
+ *
+ * Legt den uebergebenen [content] in eine Box mit Pergament-Verlauf,
+ * Gold-Rand und Schatten und ordnet ihn vertikal in einer Column an.
+ * Dient als einheitlicher Rahmen, damit alle Settings-Abschnitte gleich
+ * aussehen.
+ *
+ * @param content Die im Pergament-Rahmen dargestellten Composables.
+ */
+
 @Composable
 internal fun SettingsBackground(content: @Composable () -> Unit) {
     Box(

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/SettingsOptionSwitch.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/SettingsOptionSwitch.kt
@@ -19,6 +19,18 @@ import at.aau.serg.websocketbrokerdemo.ui.theme.ParchmentLight
 import at.aau.serg.websocketbrokerdemo.ui.theme.WoodDark
 import at.aau.serg.websocketbrokerdemo.ui.theme.WoodMedium
 
+/**
+ * Beschriftete Umschalt-Option (Label links, Switch rechts) im Settings-Screen.
+ *
+ * Genereller Baustein fuer An/Aus-Einstellungen wie Musik oder Soundeffekte.
+ * Haelt selbst keinen State -- der [checked]-Wert kommt von aussen rein,
+ * Aenderungen gehen ueber [onCheckedChange] zurueck.
+ *
+ * @param label           Beschriftung der Option.
+ * @param checked         Aktueller An/Aus-Zustand.
+ * @param onCheckedChange Callback bei Umschalten, liefert den neuen Wert.
+ */
+
 @Composable
 internal fun SettingsOptionSwitch(
     label: String,

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/SettingsSectionTitle.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/settings/components/SettingsSectionTitle.kt
@@ -7,6 +7,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import at.aau.serg.websocketbrokerdemo.ui.theme.InkBlack
 
+/**
+ * Abschnitts-Ueberschrift im Settings-Screen.
+ *
+ * Einheitlich formatierter, fetter Titel zur visuellen Gruppierung
+ * zusammengehoeriger Einstellungen.
+ *
+ * @param text Der angezeigte Ueberschriften-Text.
+ */
+
 @Composable
 internal fun SettingsSectionTitle(text: String) {
     Text(

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/Color.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/Color.kt
@@ -2,6 +2,16 @@ package at.aau.serg.websocketbrokerdemo.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+/**
+ * Zentrale Farb-Palette des HexaBrawl-Themes.
+ *
+ * Die Farben sind in vier semantische Gruppen geordnet -- Pergament
+ * (Hintergruende, Map, Cards), Tinte (Text und Linien), Holz (Buttons und
+ * Rahmen) und Metall (Muenzen und Akzente). Alle Composables beziehen ihre
+ * Farben hierueber, damit das mittelalterliche Pergament-Look konsistent
+ * bleibt und Aenderungen an einer Stelle passieren.
+ */
+
 // Pergament-Töne (Hintergrund, Map, Cards)
 val ParchmentLight = Color(0xFFF5E6C4)   // helles, sauberes Pergament
 val ParchmentBase  = Color(0xFFE8D5A8)   // Standard-Pergament


### PR DESCRIPTION
## Was

Ergänzt KDoc für die letzten 9 Frontend-Files, die bisher keine
Dokumentation hatten. Damit sind jetzt 135/135 Dateien dokumentiert.

## Betroffene Files

**Settings-Components**
- `LanguageOptionButton.kt`
- `SettingsBackButton.kt`
- `SettingsBackground.kt`
- `SettingsOptionSwitch.kt`
- `SettingsSectionTitle.kt`

**Sonstige**
- `data/SettingsDataStoreProvider.kt` (DataStore-Provider)
- `ui/components/PlayerCountBadge.kt`
- `ui/game/camera/CameraModifier.kt`
- `ui/theme/Color.kt` (Theme-Farbpalette)

## Warum

Reine Dokumentations-Ergänzung im bestehenden KDoc-Stil (deutsch, mit
`@param`-Tags). Kein Verhaltens- oder Logik-Change — keine Funktionssignatur
oder Implementierung wurde angefasst.

## Testing

Nicht nötig — dokumentationsreine Änderung, kein ausführbarer Code betroffen.