### PR TITLE
Extract UI logic mvvm

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverLogic.kt
@@ -1,0 +1,27 @@
+package at.aau.serg.websocketbrokerdemo.ui.game
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
+
+/**
+ * Reine Entscheidungs-Logik fuer das Spielende.
+ *
+ * [GameOverNavigationEffect] ist ein Composable (Navigation/Side-Effect) und
+ * damit nicht unit-testbar. Die Entscheidungen "ist das Spiel vorbei?" und
+ * "habe ich gewonnen?" liegen hier als pure, seiteneffekt-freie Funktionen.
+ */
+object GameOverLogic {
+
+    /**
+     * Ist das Spiel fuer den lokalen Spieler vorbei?
+     *  - klassisches Spielende ([GameStatus.FINISHED]), oder
+     *  - der lokale Spieler ist nicht mehr in [players] (Eliminierung im
+     *    3-/4-Spieler-Modus; der Server entfernt Ausgeschiedene aus der Liste).
+     */
+    fun isGameOver(players: List<Player>, status: GameStatus, localName: String): Boolean =
+        status == GameStatus.FINISHED || players.none { it.name == localName }
+
+    /** Hat der lokale Spieler gewonnen? (Sieger-Name == lokaler Name.) */
+    fun isLocalWinner(winner: String?, localName: String): Boolean =
+        winner == localName
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverNavigationEffect.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverNavigationEffect.kt
@@ -38,16 +38,16 @@ fun GameOverNavigationEffect(
         val state = gameState ?: return@LaunchedEffect
         val name = localName ?: return@LaunchedEffect
 
-        val iAmEliminated = state.players.none { it.name == name }
-        val gameOver = status == GameStatus.FINISHED
+        if (!GameOverLogic.isGameOver(state.players, status, name)) return@LaunchedEffect
 
-        if (iAmEliminated || gameOver) {
-            session.sessionRepository.clear()
-            val isWin = state.winner == name
-            val route = if (isWin) Screen.EndWin.route else Screen.EndLoss.route
-            navController.navigate(route) {
-                popUpTo(Screen.Home.route) { inclusive = false }
-            }
+        session.sessionRepository.clear()
+        val route = if (GameOverLogic.isLocalWinner(state.winner, name)) {
+            Screen.EndWin.route
+        } else {
+            Screen.EndLoss.route
+        }
+        navController.navigate(route) {
+            popUpTo(Screen.Home.route) { inclusive = false }
         }
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkLogic.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkLogic.kt
@@ -1,0 +1,54 @@
+package at.aau.serg.websocketbrokerdemo.ui.waiting
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.ErrorCode
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
+
+/**
+ * Reine Entscheidungs-Logik fuer die Netzwerk-Synchronisation der Wartelobby.
+ *
+ * [LobbyNetworkSync] ist ein Composable (UI/Side-Effects) und damit nicht
+ * sinnvoll unit-testbar. Alle Entscheidungen, die es trifft, liegen hier als
+ * pure, seiteneffekt-freie Funktionen -- ausserhalb der UI-Schicht und
+ * vollstaendig testbar.
+ */
+object LobbyNetworkLogic {
+
+    /**
+     * Anzahl der gestaffelten /init-Anfragen beim Lobby-Eintritt, bis der
+     * erste GameState-Broadcast eingetroffen ist.
+     */
+    const val RESYNC_REQUESTS = 5
+
+    /** Abstand zwischen zwei /init-Anfragen in Millisekunden. */
+    const val RESYNC_DELAY_MS = 400L
+
+    /**
+     * Darf der lokale Spieler jetzt beim Server angemeldet werden? Nur wenn er
+     * "Ready" geklickt hat, einen nicht-leeren Namen hat und ein Raum aktiv ist.
+     */
+    fun shouldJoin(localReady: Boolean, localName: String, roomId: String): Boolean =
+        localReady && localName.isNotBlank() && roomId.isNotBlank()
+
+    /** Ist der lokale Spieler bereits in der Server-Spielerliste enthalten? */
+    fun isLocalPlayerPresent(players: List<Player>, localName: String): Boolean =
+        players.any { it.name == localName }
+
+    /** Die Mitspieler (alle ausser dem lokalen Spieler) aus der Server-Liste. */
+    fun remotePlayers(players: List<Player>, localName: String): List<Player> =
+        players.filter { it.name != localName }
+
+    /**
+     * Soll jetzt zum GameScreen navigiert werden? Erst wenn der Countdown
+     * durchgelaufen ist UND der Server das Spiel als IN_PROGRESS meldet.
+     */
+    fun shouldNavigateToGame(countdownComplete: Boolean, status: GameStatus?): Boolean =
+        countdownComplete && status == GameStatus.IN_PROGRESS
+
+    /**
+     * Erfordert dieser Server-Fehler, dass der Spieler Name/Farbe neu waehlt
+     * (= Ready zuruecksetzen)? Trifft auf Farb- und Namens-Konflikte zu.
+     */
+    fun requiresReselection(errorCode: ErrorCode?): Boolean =
+        errorCode == ErrorCode.COLOR_ALREADY_TAKEN || errorCode == ErrorCode.NAME_ALREADY_TAKEN
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkSync.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import at.aau.serg.websocketbrokerdemo.data.serverside.ErrorCode
-import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
 import at.aau.serg.websocketbrokerdemo.data.serverside.PlayerColor
 import at.aau.serg.websocketbrokerdemo.network.GameSession
 import at.aau.serg.websocketbrokerdemo.ui.navigation.Screen
@@ -16,15 +14,18 @@ import kotlinx.coroutines.delay
 /**
  * Verbindet das Wartelobby-ViewModel mit dem GameSession-Netzwerk.
  *
+ * Reine Side-Effect-/Wiring-Schicht: Subscription verwalten, Server-Calls
+ * absetzen und Navigation ausloesen. Saemtliche Entscheidungen (wann anmelden,
+ * wer ist remote, wann navigieren, welcher Fehler braucht Reselection) liegen
+ * in [LobbyNetworkLogic] -- pure und getestet.
+ *
  * Verantwortungen:
  *  - GameState-Subscription verwalten (DisposableEffect)
- *  - Server-Updates an [WaitingLobbyViewModel.applyRemoteState]
- *    weiterreichen
- *  - Lokalen Spieler erst dann beim Server anmelden, wenn der User
- *    "Ready" geklickt hat -- vorher hat er Zeit, Name und Farbe zu
- *    waehlen
- *  - Zum GameScreen navigieren, sobald der Countdown durchgelaufen ist
- *    UND der Server den Spielstatus auf IN_PROGRESS gesetzt hat
+ *  - Aktuellen Raum-Zustand beim Eintritt anfordern (Resync)
+ *  - Lokalen Spieler beim Server anmelden, sobald "Ready" geklickt ist
+ *  - Server-Updates an [WaitingLobbyViewModel.applyRemoteState] weiterreichen
+ *  - Zum GameScreen navigieren, sobald Countdown durch + Spiel IN_PROGRESS
+ *  - Server-Fehler behandeln (Snackbar; bei Farb-/Namens-Konflikt Ready-Reset)
  */
 @Composable
 fun LobbyNetworkSync(
@@ -33,11 +34,8 @@ fun LobbyNetworkSync(
     navController: NavController
 ) {
     val viewModelState by viewModel.state.collectAsStateWithLifecycle()
-    // Lokale Werte direkt aus dem observed State ableiten -- damit Compose
-    // die Recomposition garantiert triggert, wenn der User Name, Farbe
-    // oder Ready-Status aendert. Direkte Aufrufe von viewModel.localXyz
-    // wurden zwar gelesen, aber nicht zuverlaessig fuer LaunchedEffect-Keys
-    // erfasst.
+    // Lokale Werte aus dem observed State ableiten, damit Compose die
+    // Recomposition (und damit die LaunchedEffect-Keys) zuverlaessig triggert.
     val localSlot = viewModelState.slots.firstOrNull { it.isLocal }
     val localName = localSlot?.name.orEmpty()
     val localColor = localSlot?.color ?: PlayerColor.RED
@@ -50,41 +48,23 @@ fun LobbyNetworkSync(
         onDispose { job.cancel() }
     }
 
-    // Aktuellen Raum-Zustand aktiv anfordern.
-    //
-    // STOMP-Subscriptions liefern nur zukuenftige Broadcasts. Ein spaet
-    // beitretender Spieler wuerde die bereits anwesenden Spieler und deren
-    // belegte Farben sonst nie sehen -- er bliebe auf der Default-Farbe,
-    // wuerde beim "Ready" mit COLOR_ALREADY_TAKEN abgelehnt und der Raum
-    // erreicht nie die volle Spielerzahl (kein Auto-Start). Mit dem
-    // angeforderten State greift der Auto-Reassign in
-    // applyRemoteState, bevor der User "Ready" drueckt.
-    //
-    // Gestaffelte Wiederholung: der erste Request kann die Subscribe-
-    // Registrierung am Broker knapp verpassen (Subscribe und Send laufen in
-    // getrennten Coroutines). Wir fragen daher mehrfach, bis der erste
-    // Broadcast eintrifft -- danach stoppt die Schleife. Die Requests sind
-    // idempotent (der Server rebroadcastet nur).
+    // Aktuellen Raum-Zustand aktiv anfordern (STOMP liefert nur zukuenftige
+    // Broadcasts). Gestaffelt, bis der erste Broadcast eintrifft -- danach
+    // stoppt die Schleife. Idempotent (Server rebroadcastet nur).
     LaunchedEffect(session.activeRoomId.value) {
         val roomId = session.activeRoomId.value
         if (roomId.isBlank()) return@LaunchedEffect
-        repeat(MAX_ROOM_STATE_REQUESTS) {
+        repeat(LobbyNetworkLogic.RESYNC_REQUESTS) {
             if (session.gameState.value != null) return@LaunchedEffect
             session.endpoint.requestRoomState(roomId)
-            delay(ROOM_STATE_REQUEST_DELAY_MS)
+            delay(LobbyNetworkLogic.RESYNC_DELAY_MS)
         }
     }
 
-    // Anmelden erst wenn der User "Ready" geklickt hat.
-    //
-    // Der User hat in der WaitingLobby zuvor seinen Namen und seine Farbe
-    // gewaehlt. Der Klick auf "Ready" setzt im lokalen Slot ready=true
-    // und triggert diesen Effect. Die gewaehlte Farbe wird mitgegeben --
-    // bei Konflikt (zwei Spieler waehlen die gleiche Farbe) lehnt der
-    // Server mit COLOR_ALREADY_TAKEN ab; das Error-Handling dafuer kommt
-    // als Follow-up.
+    // Beim Server anmelden, sobald der User "Ready" geklickt hat (Name/Farbe
+    // sind dann gewaehlt).
     LaunchedEffect(localReady, localName, localColor) {
-        if (localReady && localName.isNotBlank() && session.activeRoomId.value.isNotBlank()) {
+        if (LobbyNetworkLogic.shouldJoin(localReady, localName, session.activeRoomId.value)) {
             session.localPlayerName.value = localName
             session.sessionRepository.playerName = localName
             session.endpoint.joinGame(
@@ -97,74 +77,36 @@ fun LobbyNetworkSync(
 
     val gameState by session.gameState
 
-    // Server-Updates an das ViewModel weiterreichen (Slots, Spielerliste).
-    // Navigation passiert bewusst NICHT hier, sondern erst nachdem der
-    // Countdown im ViewModel abgelaufen ist (siehe LaunchedEffect unten).
+    // Server-Updates ans ViewModel weiterreichen. Navigation passiert bewusst
+    // erst nach dem Countdown (siehe LaunchedEffect unten).
     LaunchedEffect(gameState) {
         val state = gameState ?: return@LaunchedEffect
-
-        // Lokalen Spieler im Server-State erkennen -> Name + Farbe locken.
-        // Wir verlassen uns nicht auf den joinGame-Send, sondern auf den
-        // tatsaechlichen Broadcast: wenn der Server den Spieler ablehnt
-        // (z.B. COLOR_ALREADY_TAKEN), taucht er nicht in der Liste auf
-        // und der Lock bleibt offen, sodass der User die Farbe wechseln
-        // kann.
-        if (state.players.any { it.name == localName }) {
+        if (LobbyNetworkLogic.isLocalPlayerPresent(state.players, localName)) {
             viewModel.markJoinedServer()
         }
-
-        // Komplette Player-Objekte (mit Server-Farbe) weitergeben, damit
-        // der Color-Picker im Wartelobby-UI konsistent zur Realitaet ist.
-        val remotePlayers = state.players.filter { it.name != localName }
-
-        viewModel.applyRemoteState(remotePlayers)
+        viewModel.applyRemoteState(LobbyNetworkLogic.remotePlayers(state.players, localName))
     }
 
-    // Zum GameScreen navigieren -- aber erst NACHDEM der Countdown
-    // wirklich durchgelaufen ist. So sieht der User die 3-2-1-Anzeige,
-    // auch wenn der Server (Auto-Start sobald maxPlayers erreicht) den
-    // Status schon vorher auf IN_PROGRESS gesetzt hat.
+    // Zum GameScreen navigieren -- erst NACHDEM der Countdown durchgelaufen ist
+    // UND der Server IN_PROGRESS meldet.
     LaunchedEffect(viewModelState.countdownComplete, gameState?.status) {
-        val status = gameState?.status ?: return@LaunchedEffect
-        if (viewModelState.countdownComplete && status == GameStatus.IN_PROGRESS) {
+        if (LobbyNetworkLogic.shouldNavigateToGame(viewModelState.countdownComplete, gameState?.status)) {
             navController.navigate(Screen.Game.route) {
                 popUpTo(Screen.Home.route) { inclusive = false }
             }
         }
     }
 
-    // Server-Fehler beobachten und sinnvoll behandeln.
-    //
-    // COLOR_ALREADY_TAKEN / NAME_ALREADY_TAKEN: der lokale Spieler hat eine
-    // Farbe bzw. einen Namen gewaehlt, die/der schon belegt war. Wir setzen
-    // den ready-Status zurueck (damit Name/Farbe wieder editierbar sind) und
-    // zeigen eine Snackbar mit einem klaren Hinweis.
-    //
-    // Andere Fehler werden 1:1 als Snackbar gezeigt; die App bleibt
-    // ansonsten im aktuellen State.
+    // Server-Fehler behandeln: Snackbar; bei Farb-/Namens-Konflikt zusaetzlich
+    // Ready zuruecksetzen, damit Name/Farbe wieder editierbar sind.
     val lastError by session.lastError
     LaunchedEffect(lastError) {
         val error = lastError ?: return@LaunchedEffect
-        when (error.errorCode) {
-            ErrorCode.COLOR_ALREADY_TAKEN, ErrorCode.NAME_ALREADY_TAKEN -> {
-                viewModel.clearLocalReady()
-                viewModel.showError(error.message)
-            }
-            else -> {
-                viewModel.showError(error.message)
-            }
+        if (LobbyNetworkLogic.requiresReselection(error.errorCode)) {
+            viewModel.clearLocalReady()
         }
-        // Error in der Session wieder loeschen, sonst triggert derselbe
-        // Effect bei jeder Recomposition erneut.
+        viewModel.showError(error.message)
+        // Error loeschen, sonst triggert derselbe Effect bei jeder Recomposition.
         session.lastError.value = null
     }
 }
-
-/**
- * Maximale Anzahl gestaffelter /init-Anfragen beim Betreten der Wartelobby,
- * bis der erste GameState-Broadcast eingetroffen ist.
- */
-private const val MAX_ROOM_STATE_REQUESTS = 5
-
-/** Abstand zwischen zwei /init-Anfragen in Millisekunden. */
-private const val ROOM_STATE_REQUEST_DELAY_MS = 400L

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/game/GameOverLogicTest.kt
@@ -1,0 +1,47 @@
+package at.aau.serg.websocketbrokerdemo.ui.game
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GameOverLogicTest {
+
+    private val alice = "Alice"
+    private val bob = "Bob"
+    private fun player(name: String) = Player(name = name)
+
+    // ---- isGameOver ----------------------------------------------------
+
+    @Test
+    fun `isGameOver true when status FINISHED`() {
+        val players = listOf(player(alice), player(bob))
+        assertTrue(GameOverLogic.isGameOver(players, GameStatus.FINISHED, alice))
+    }
+
+    @Test
+    fun `isGameOver true when local player no longer in list (eliminated)`() {
+        val players = listOf(player(bob)) // Alice ausgeschieden
+        assertTrue(GameOverLogic.isGameOver(players, GameStatus.IN_PROGRESS, alice))
+    }
+
+    @Test
+    fun `isGameOver false when in progress and local player present`() {
+        val players = listOf(player(alice), player(bob))
+        assertFalse(GameOverLogic.isGameOver(players, GameStatus.IN_PROGRESS, alice))
+    }
+
+    // ---- isLocalWinner -------------------------------------------------
+
+    @Test
+    fun `isLocalWinner true when winner equals local name`() {
+        assertTrue(GameOverLogic.isLocalWinner(alice, alice))
+    }
+
+    @Test
+    fun `isLocalWinner false for other winner or null`() {
+        assertFalse(GameOverLogic.isLocalWinner(bob, alice))
+        assertFalse(GameOverLogic.isLocalWinner(null, alice))
+    }
+}

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkLogicTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/ui/waiting/LobbyNetworkLogicTest.kt
@@ -1,0 +1,86 @@
+package at.aau.serg.websocketbrokerdemo.ui.waiting
+
+import at.aau.serg.websocketbrokerdemo.data.serverside.ErrorCode
+import at.aau.serg.websocketbrokerdemo.data.serverside.GameStatus
+import at.aau.serg.websocketbrokerdemo.data.serverside.Player
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LobbyNetworkLogicTest {
+
+    private val alice = "Alice"
+    private val bob = "Bob"
+    private fun player(name: String) = Player(name = name)
+
+    // ---- shouldJoin ----------------------------------------------------
+
+    @Test
+    fun `shouldJoin true when ready, name and room present`() {
+        assertTrue(LobbyNetworkLogic.shouldJoin(localReady = true, localName = alice, roomId = "room1"))
+    }
+
+    @Test
+    fun `shouldJoin false when not ready`() {
+        assertFalse(LobbyNetworkLogic.shouldJoin(localReady = false, localName = alice, roomId = "room1"))
+    }
+
+    @Test
+    fun `shouldJoin false when name blank`() {
+        assertFalse(LobbyNetworkLogic.shouldJoin(localReady = true, localName = "  ", roomId = "room1"))
+    }
+
+    @Test
+    fun `shouldJoin false when roomId blank`() {
+        assertFalse(LobbyNetworkLogic.shouldJoin(localReady = true, localName = alice, roomId = ""))
+    }
+
+    // ---- isLocalPlayerPresent / remotePlayers --------------------------
+
+    @Test
+    fun `isLocalPlayerPresent reflects membership by name`() {
+        val players = listOf(player(alice), player(bob))
+        assertTrue(LobbyNetworkLogic.isLocalPlayerPresent(players, alice))
+        assertFalse(LobbyNetworkLogic.isLocalPlayerPresent(players, "Carol"))
+    }
+
+    @Test
+    fun `remotePlayers excludes the local player`() {
+        val players = listOf(player(alice), player(bob))
+        val remotes = LobbyNetworkLogic.remotePlayers(players, alice)
+        assertEquals(listOf(bob), remotes.map { it.name })
+    }
+
+    // ---- shouldNavigateToGame ------------------------------------------
+
+    @Test
+    fun `shouldNavigateToGame true only when countdown done and in progress`() {
+        assertTrue(LobbyNetworkLogic.shouldNavigateToGame(true, GameStatus.IN_PROGRESS))
+    }
+
+    @Test
+    fun `shouldNavigateToGame false when countdown not complete`() {
+        assertFalse(LobbyNetworkLogic.shouldNavigateToGame(false, GameStatus.IN_PROGRESS))
+    }
+
+    @Test
+    fun `shouldNavigateToGame false when not in progress or status null`() {
+        assertFalse(LobbyNetworkLogic.shouldNavigateToGame(true, GameStatus.WAITING_FOR_PLAYERS))
+        assertFalse(LobbyNetworkLogic.shouldNavigateToGame(true, null))
+    }
+
+    // ---- requiresReselection -------------------------------------------
+
+    @Test
+    fun `requiresReselection true for color and name conflicts`() {
+        assertTrue(LobbyNetworkLogic.requiresReselection(ErrorCode.COLOR_ALREADY_TAKEN))
+        assertTrue(LobbyNetworkLogic.requiresReselection(ErrorCode.NAME_ALREADY_TAKEN))
+    }
+
+    @Test
+    fun `requiresReselection false for other or null errors`() {
+        assertFalse(LobbyNetworkLogic.requiresReselection(ErrorCode.GAME_FULL))
+        assertFalse(LobbyNetworkLogic.requiresReselection(null))
+    }
+}


### PR DESCRIPTION

## Summary

Moves the remaining decision logic out of two Composables into pure,
tested logic objects — keeping the UI layer free of business/decision
logic (MVVM / SE code-hygiene). Pure refactor, no behaviour change.

## Changes

**LobbyNetworkSync → LobbyNetworkLogic**
- New `LobbyNetworkLogic` (pure, testable) holds the decisions the sync
  Composable used to make inline: `shouldJoin`, `isLocalPlayerPresent`,
  `remotePlayers`, `shouldNavigateToGame`, `requiresReselection`, plus the
  resync constants.
- `LobbyNetworkSync` is now pure wiring: it only manages the subscription,
  fires server calls / navigation, and delegates every decision to
  `LobbyNetworkLogic`.

**GameOverNavigationEffect → GameOverLogic**
- New `GameOverLogic` (pure, testable) with `isGameOver` (FINISHED or local
  player eliminated from the list) and `isLocalWinner`.
- `GameOverNavigationEffect` now only clears the session and navigates;
  the win/over decision lives in `GameOverLogic`.

## Tests

- `LobbyNetworkLogicTest` (10 cases) and `GameOverLogicTest` (5 cases)
  cover all extracted decisions.
- The new `*Logic` objects are **not** in the coverage exclusions (pure,
  tested); the two Composables stay excluded as UI/effect wiring.
- `./gradlew :app:testDebugUnitTest` passes.

## Notes

- No behaviour change — the conditions are 1:1 the previous inline logic.
- Consistent with the earlier GameScreen split
  (`GameStateResyncEffect`/`GameStateResyncLogic`).
- Borderline left as-is: `EndScreen.getEndScreenBackground` selects a
  drawable by language/win — that's UI resource mapping, not game logic.
  Can be extracted on request.